### PR TITLE
We now use the invariant culture when generation IOS8601 timestamps.

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -917,7 +917,7 @@ namespace nsRSMPGS
 
     public string CreateISO8601UTCTimeStamp(DateTime dtLocalTimeStamp)
     {
-      string sTimeStamp = String.Format("{0:yyyy-MM-dd}T{0:HH:mm:ss.fff}Z", dtLocalTimeStamp.ToUniversalTime());
+      string sTimeStamp = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:yyyy-MM-dd}T{0:HH:mm:ss.fff}Z", dtLocalTimeStamp.ToUniversalTime());
       return sTimeStamp;
     }
 


### PR DESCRIPTION
On Danish systems the String format function for dates will convert the ":" in the format string to "." in the default locale, so I added `System.Globalization.CultureInfo.InvariantCulture` forcing it to use ":" on all systems, and behave deterministically on all systems.