### PR TITLE
We now put the full expected path of the settings file in the warning

### DIFF
--- a/RSMPCommon/RSMPGS_Main.cs
+++ b/RSMPCommon/RSMPGS_Main.cs
@@ -77,7 +77,7 @@ namespace nsRSMPGS
 
       if (File.Exists(RSMPGS.IniFileFullname) == false)
       {
-        MessageBox.Show("Configuration file '" + RSMPGS.IniFileFullname + "' is missing!", "RSMP Protocol Simulator", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        MessageBox.Show("Configuration file '" + Path.GetFullPath(RSMPGS.IniFileFullname) + "' is missing!", "RSMP Protocol Simulator", MessageBoxButtons.OK, MessageBoxIcon.Error);
         bLoadFailed = true;
         this.Close();
         return;


### PR DESCRIPTION
The warning for missing settings file now shows the full path, so it is easier to put it in the correct place