### PR TITLE
Add dropdown selection when loading SXL from YAML-file

### DIFF
--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -734,6 +734,7 @@ namespace nsRSMPGS
                 }
               }
             }
+            this.SelectableValues = SelectableValues;
             break;
 
           case eValueType._raw:

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -61,7 +61,7 @@ namespace nsRSMPGS
               aCommands[j] = aCommands[j].TrimEnd('"');
             }
             */
-          if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.count == 0) || aCommands.Length < 2)
+          if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.Count == 0) || aCommands.Length < 2)
           {
             DataGridViewTextBoxCell txtcell = new DataGridViewTextBoxCell();
             this.dataGridView_Commands.Rows.Add(bWasSelected, CommandObject.sCommandCodeId, CommandArguments.sName, CommandArguments.sCommand);

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -61,7 +61,7 @@ namespace nsRSMPGS
               aCommands[j] = aCommands[j].TrimEnd('"');
             }
             */
-            if ((CommandArguments.Value.ValueTypeObject.sRange == "" || aCommands.Length < 2))
+          if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.count == 0) || aCommands.Length < 2)
           {
             DataGridViewTextBoxCell txtcell = new DataGridViewTextBoxCell();
             this.dataGridView_Commands.Rows.Add(bWasSelected, CommandObject.sCommandCodeId, CommandArguments.sName, CommandArguments.sCommand);

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -50,7 +50,20 @@ namespace nsRSMPGS
             }
           }
 
-          if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.Count == 0) || aCommands.Length < 2)
+          // 
+          if (CommandArguments.Value.GetValueType().Equals("boolean", StringComparison.OrdinalIgnoreCase))
+          {
+            // Create a selectable list of boolean elements if YAML format is used.
+            // (If CSV format is used, it uses whatever defined in the "Values" column)
+            if (aCommands.Length < 2)
+            {
+              aCommands.Append("True");
+              aCommands.Append("False");
+            }
+ 
+          }
+
+          if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.Count == 0) && aCommands.Length < 2)
           {
             DataGridViewTextBoxCell txtcell = new DataGridViewTextBoxCell();
             this.dataGridView_Commands.Rows.Add(bWasSelected, CommandObject.sCommandCodeId, CommandArguments.sName, CommandArguments.sCommand);

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -50,17 +50,6 @@ namespace nsRSMPGS
             }
           }
 
-
-            /*
-                string[] aCommands = CommandArguments.sValue.Split('\n');
-
-            for (int j = 0; j < aCommands.Length; j++)
-            {
-              aCommands[j] = aCommands[j].TrimStart('"');
-              aCommands[j] = aCommands[j].TrimStart('-');
-              aCommands[j] = aCommands[j].TrimEnd('"');
-            }
-            */
           if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.Count == 0) || aCommands.Length < 2)
           {
             DataGridViewTextBoxCell txtcell = new DataGridViewTextBoxCell();

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -36,7 +36,7 @@ namespace nsRSMPGS
           string[] aCommands;
           if (CommandArguments.Value.ValueTypeObject.SelectableValues != null && CommandArguments.Value.ValueTypeObject.SelectableValues.Count > 0)
           {
-            aCommands = CommandArguments.Value.ValueTypeObject.SelectableValues.Values.ToArray<string>();
+            aCommands = CommandArguments.Value.ValueTypeObject.SelectableValues.Keys.ToArray<string>();
           }
           else
           {


### PR DESCRIPTION
Fixes https://github.com/rsmp-nordic/rsmp_simulator/issues/52

Work in progress

- [x] Makes CSV loading use SelectableValues instead, but it currently most likely only works for strings
- [x] Needs to handle boolean (both CSV and YAML). Check and compare how it boolean works with CSV