### PR TITLE
Add option for checking case sensitive in values (RSMP 3.2)

### DIFF
--- a/Documents/Manual_RSMPGS1.rst
+++ b/Documents/Manual_RSMPGS1.rst
@@ -493,8 +493,14 @@ The RSMP versions the simulator will allow and use when connecting are selected
 by the first row.
 
 The setting *Use strict and unforgiving protocol parsing* enables a more strict
-mode, where amongst other protocol checking all JSon names and (where
-applicable) values are case-sensitive.
+mode, where amongst other protocol checking all JSon names.
+
+The setting *Use case sensitive lookup for object id's and references* enables
+case sensitive check for componentId, statusCodeId, alarmCodeId, commandCodeId
+and "name" in arguments/return values.
+
+The setting *Use case sensitive value* enables case sensitive checks for the
+values in alarms, statuses and commands.
 
 Each individual setting is not explained in this document, since they mostly
 reflects the version document history of the RSMP protocol and the protocol

--- a/Documents/Manual_RSMPGS2.rst
+++ b/Documents/Manual_RSMPGS2.rst
@@ -480,8 +480,14 @@ The RSMP versions the simulator will allow and use when connecting are selected
 by the first row.
 
 The setting *Use strict and unforgiving protocol parsing* enables a more strict
-mode, where amongst other protocol checking all JSon names and (where
-applicable) values are case-sensitive.
+mode, where amongst other protocol checking all JSon names.
+
+The setting *Use case sensitive lookup for object id's and references* enables
+case sensitive check for componentId, statusCodeId, alarmCodeId, commandCodeId
+and "name" in arguments/return values.
+
+The setting *Use case sensitive value* enables case sensitive checks for the
+values in alarms, statuses and commands.
 
 Each individual setting is not explained in this document, since they mostly
 reflects the version document history of the RSMP protocol and the protocol

--- a/RSMPCommon/RSMPGS_Helper.cs
+++ b/RSMPCommon/RSMPGS_Helper.cs
@@ -1934,9 +1934,9 @@ namespace nsRSMPGS
 
       form.Text = title + " (" + Value.GetValueType() + ")";
 
-      if (Value.ValueTypeObject.sRange.Length > 0)
+      if (Value.ValueTypeObject.GetValueMax() > 0)
       {
-        form.Text += " / " + Value.ValueTypeObject.sRange;
+        form.Text += " / [" + Value.ValueTypeObject.GetValueMin().ToString() + "-" + Value.ValueTypeObject.GetValueMax().ToString() + "]";
       }
 
       //label.Text = promptText;
@@ -2093,8 +2093,14 @@ namespace nsRSMPGS
     {
 
       cInputBoxValue InputBoxValue = (cInputBoxValue)comboBox.Tag;
+      Dictionary<string, string> eNums = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-      if (RSMPGS.JSon.ValidateTypeAndRange(InputBoxValue.sType, comboBox.Text, InputBoxValue.sValues))
+      foreach(string sValueItem in InputBoxValue.sValues.Split('\n'))
+      {
+        eNums.Add(sValueItem, "");
+      }
+
+      if (RSMPGS.JSon.ValidateTypeAndRange(InputBoxValue.sType, comboBox.Text, eNums))
       {
         comboBox.ForeColor = default(Color);
         comboBox.BackColor = default(Color);

--- a/RSMPCommon/RSMPGS_Helper.cs
+++ b/RSMPCommon/RSMPGS_Helper.cs
@@ -530,6 +530,7 @@ namespace nsRSMPGS
 #endif
       AddSetting("UseStrictProtocolAnalysis", "Use strict and unforgiving protocol parsing", false, true, true, true, true, true);
       AddSetting("UseCaseSensitiveIds", "Use case sensitive lookup for object id's and references", false, true, true, true, true, true);
+      AddSetting("UseCaseSensitiveValue", "Use case sensitive value", false, false, false, false, false, true);
       AddSetting("DontAckPackets", "Never Ack or NAck packets", false);
       AddSetting("ResendUnackedPackets", "Resend unacked packets", true);
       AddSetting("WaitInfiniteForUnackedPackets", "Wait infinite for packet Ack / NAcks", false);

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1140,12 +1140,12 @@ namespace nsRSMPGS
       }
     }
 
-    public bool ValidateTypeAndRange(string sType, string sValue)
+    public bool ValidateTypeAndRange(string sType, string sValue, Dictionary<string, string> sEnums)
     {
-      return ValidateTypeAndRange(sType, sValue, "");
+      return ValidateTypeAndRange(sType, sValue, sEnums, 0, 0);
     }
 
-    public bool ValidateTypeAndRange(string sType, string sValue, string sValues)
+    public bool ValidateTypeAndRange(string sType, string sValue, Dictionary<string, string> sEnums, double dMin, double dMax)
     {
       bool bUseCaseSensitiveValue = cHelper.IsSettingChecked("UseCaseSensitiveValue");
       var comparisonType = StringComparison.Ordinal;
@@ -1237,7 +1237,7 @@ namespace nsRSMPGS
       }
 
       // Validate range
-      if (bValueIsValid == true && sValues != "")
+      if (bValueIsValid == true)
       {
         switch (sType.ToLower())
         {
@@ -1248,68 +1248,39 @@ namespace nsRSMPGS
             try
             {
               Double dValue = Double.Parse(sValue);
-              if (sValues.StartsWith("[") && sValues.EndsWith("]"))
+              bValueIsValid = dValue <= dMax && dValue >= dMin;
+
+              if (sEnums.Count > 0)
               {
-                string sRange = sValues.Substring(1, sValues.Length - 2);
-                if (sRange.Contains("-"))
+                bValueIsValid = false;
+                foreach (string sEnum in sEnums.Keys)
                 {
-                  Double dMin = Double.Parse(sRange.Split('-')[0]);
-                  Double dMax = Double.Parse(sRange.Split('-')[1]);
-                  bValueIsValid = dValue <= dMax && dValue >= dMin;
-                }
-                else
-                {
-                  bValueIsValid = (dValue == Double.Parse(sRange)) ? true : false;
-                }
-              }
-              else
-              {
-                if (sValues.StartsWith("-"))
-                {
-                  bValueIsValid = false;
-                  foreach (string sValueItem in sValues.Split('\n'))
+                  if (sValue == sEnum)
                   {
-                    if (sValueItem.StartsWith("-"))
-                    {
-                      try
-                      {
-                        if (dValue == Double.Parse(sValueItem.Substring(1)))
-                        {
-                          bValueIsValid = true;
-                          break;
-                        }
-                      }
-                      catch { }
-                    }
+                    bValueIsValid = true;
                   }
                 }
               }
             }
             catch { }
-
             break;
-
           case "string":
 
-            if (sValues.StartsWith("-"))
+            try
             {
-              bValueIsValid = false;
-              foreach (string sValueItem in sValues.Split('\n'))
+              if (sEnums.Count > 0)
               {
-                if (sValueItem.StartsWith("-"))
+                bValueIsValid = false;
+                foreach (string sEnum in sEnums.Keys)
                 {
-                  try
+                  if (sValue == sEnum)
                   {
-                    if (sValue == sValueItem.Substring(1))
-                    {
-                      bValueIsValid = true;
-                      break;
-                    }
+                    bValueIsValid = true;
                   }
-                  catch { }
                 }
               }
             }
+            catch { }
             break;
         }
       }

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1193,10 +1193,13 @@ namespace nsRSMPGS
           break;
 
         case "boolean":
-          bValueIsValid = sValue.Equals("true", comparisonType) ||
-            sValue.Equals("false", comparisonType) ||
-            sValue.Equals("0", comparisonType) ||
-            sValue.Equals("1", comparisonType);
+          // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
+          // preserve backwards compability we need to treat this as case
+          // insensitive for now
+          bValueIsValid = sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+            sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+            sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+            sValue.Equals("1", StringComparison.OrdinalIgnoreCase);
           break;
 
         case "base64":

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1147,6 +1147,9 @@ namespace nsRSMPGS
 
     public bool ValidateTypeAndRange(string sType, string sValue, string sValues)
     {
+      bool bUseCaseSensitiveValue = cHelper.IsSettingChecked("UseCaseSensitiveValue");
+      var comparisonType = StringComparison.Ordinal;
+      if (!bUseCaseSensitiveValue) { comparisonType = StringComparison.OrdinalIgnoreCase; }
 
       if (sValue == null)
       {
@@ -1190,10 +1193,10 @@ namespace nsRSMPGS
           break;
 
         case "boolean":
-          bValueIsValid = sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("1", StringComparison.OrdinalIgnoreCase);
+          bValueIsValid = sValue.Equals("true", comparisonType) ||
+            sValue.Equals("false", comparisonType) ||
+            sValue.Equals("0", comparisonType) ||
+            sValue.Equals("1", comparisonType);
           break;
 
         case "base64":

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1255,7 +1255,7 @@ namespace nsRSMPGS
                 bValueIsValid = false;
                 foreach (string sEnum in sEnums.Keys)
                 {
-                  if (sValue == sEnum)
+                  if (sValue.Equals(sEnum, comparisonType))
                   {
                     bValueIsValid = true;
                   }
@@ -1273,7 +1273,7 @@ namespace nsRSMPGS
                 bValueIsValid = false;
                 foreach (string sEnum in sEnums.Keys)
                 {
-                  if (sValue == sEnum)
+                  if (sValue.Equals(sEnum, comparisonType))
                   {
                     bValueIsValid = true;
                   }

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -65,8 +65,8 @@ namespace RSMP_Messages
 
   public class AlarmReturnValue
   {
+    public string aCId; // AlarmCodeId
     public string n; // name
-    //        public string t; // type
     public string v; // value
   }
 

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -12,6 +12,7 @@ using System.Xml.Serialization;
 using System.Windows.Forms;
 using static nsRSMPGS.cJSon;
 using System.Diagnostics;
+using static nsRSMPGS.cValueTypeObject;
 
 namespace nsRSMPGS
 {
@@ -685,6 +686,15 @@ namespace nsRSMPGS
       this.sComment = sComment;
       this.SelectableValues = SelectableValues;
       this.sName = sName;
+
+      foreach (eValueType valueType in Enum.GetValues(typeof(eValueType)))
+      {
+        if (sType.Equals(valueType.ToString().Substring(1), StringComparison.OrdinalIgnoreCase))
+        {
+          ValueType = valueType;
+          break;
+        }
+      }
     }
 
     public Dictionary<string, string> GetSelectableValues()

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -779,7 +779,9 @@ namespace nsRSMPGS
 
         case eValueType._boolean:
 
-          // Ej uppdaterat
+          // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
+          // preserve backwards compability we need to treat this as case
+          // insensitive for now
           if (sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
             sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
             sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -521,6 +521,21 @@ namespace nsRSMPGS
       old
     }
 
+    public Dictionary<string, string> GetSelectableValues()
+    {
+      return ValueTypeObject.GetSelectableValues();
+    }
+
+    public double GetValueMin()
+    {
+      return ValueTypeObject.GetValueMin();
+    }
+
+    public double GetValueMax()
+    {
+      return ValueTypeObject.GetValueMax();
+    }
+
     public string GetValueType()
     {
       return ValueTypeObject.GetValueTypeAsString();
@@ -834,6 +849,21 @@ namespace nsRSMPGS
 
       Debug.WriteLine("cValueTypeObject: " + sValueTypeKey + "\t" + ValueType.ToString() + "\t" + "Range: " + sRange + "\t" + "Values: " + sSelectableValues + "\t" + "sComment: " + sComment.Replace("\n", "\\n"));
       */
+    }
+
+    public Dictionary<string, string> GetSelectableValues()
+    {
+      return this.SelectableValues;
+    }
+
+    public double GetValueMin()
+    {
+      return this.dMinValue;
+    }
+
+    public double GetValueMax()
+    {
+      return this.dMaxValue;
     }
 
     public string GetValueTypeAsString()

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -660,11 +660,13 @@ namespace nsRSMPGS
 
     public eValueType ValueType;
 
-    public cValueTypeObject(string sValueTypeKey, string sName, string sType, string sRange, Dictionary<string, string> SelectableValues, string sComment)
+    public cValueTypeObject(string sValueTypeKey, string sName, string sType, string sRange, Dictionary<string, string> SelectableValues, double dMin, double dMax, string sComment)
     {
 
       this.sValueTypeKey = sValueTypeKey;
       this.sRange = sRange;
+      this.dMinValue = dMin;
+      this.dMaxValue = dMax;
       this.sComment = sComment;
       this.SelectableValues = SelectableValues;
       this.sName = sName;

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -733,8 +733,13 @@ namespace nsRSMPGS
           {
             foreach (string sScanValue in SelectableValues.Keys)
             {
-              // Behöver uppdatering
-              if (sScanValue.Equals(sValue, StringComparison.OrdinalIgnoreCase))
+              bool bUseCaseSensitiveValue = cHelper.IsSettingChecked("UseCaseSensitiveValue");
+              var comparisonType = StringComparison.Ordinal;
+              if (!bUseCaseSensitiveValue) {
+                comparisonType = StringComparison.OrdinalIgnoreCase;
+              }
+
+              if (sScanValue.Equals(sValue, comparisonType))
               {
                 return true;
               }

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -1231,7 +1231,7 @@ namespace nsRSMPGS
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Failed to parse value and range: {0}", sValueTypeKey.Replace("\t", "/"));
         }
 
-        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, "", eNums, dMin, dMax, sComment);
+        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, sRange, eNums, dMin, dMax, sComment);
 
         ValueTypeObjects.Add(sValueTypeKey, ValueTypeObject);
       }

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -1198,13 +1198,18 @@ namespace nsRSMPGS
               case eValueType._long:
               case eValueType._ordinal:
               case eValueType._real:
-                if (Double.TryParse(sRange.Split('-')[0], out dMin) == false)
+                sRange = sRange.Substring(1, sRange.Length - 2); // Remove []
+                char[] sep = new char[] { '-' };
+                string[] sRangeArray = sRange.Split(sep, StringSplitOptions.RemoveEmptyEntries);
+                string sMin = sRangeArray[0];
+                string sMax = sRangeArray[1];
+                if (Double.TryParse(sMin, out dMin) == false)
                 {
-                  dMin = Double.Parse(sRange.Split('-')[0]);
+                  dMin = Double.Parse(sMin);
                 }
-                if (Double.TryParse(sRange.Split('-')[1], out dMax) == false)
+                if (Double.TryParse(sMax, out dMax) == false)
                 {
-                  dMax = Double.Parse(sRange.Split('-')[1]);
+                  dMax = Double.Parse(sMax);
                 }
                 break;
             }

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -181,6 +181,8 @@ namespace nsRSMPGS
 
                     string sType = YAMLArgument.GetScalar("type");
                     string sRange = YAMLArgument.GetScalar("range");
+                    double dMin = YAMLArgument.GetScalar("min") != "" ? double.Parse(YAMLArgument.GetScalar("min")) : 0;
+                    double dMax = YAMLArgument.GetScalar("max") != "" ? double.Parse(YAMLArgument.GetScalar("max")) : 0;
 
                     string sDescription = YAMLArgument.GetScalar("description");
 

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -209,11 +209,11 @@ namespace nsRSMPGS
                       cYAMLMapping Values;
                       if (YAMLArgument.YAMLMappings.TryGetValue("values", out Values))
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", Values.YAMLScalars, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", Values.YAMLScalars, dMin, dMax, sDescription);
                       }
                       else
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", null, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", null, dMin, dMax, sDescription);
                       }
                       if (ValueTypeObjects.ContainsKey(sValueTypeKey))
                       {
@@ -1172,7 +1172,7 @@ namespace nsRSMPGS
       else
       {
 
-        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, sRange, null, sComment);
+        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, sRange, null, 0, 0, sComment);
 
         ValueTypeObjects.Add(sValueTypeKey, ValueTypeObject);
       }

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -180,7 +180,6 @@ namespace nsRSMPGS
                     string sValueTypeKey = YAMLObjectType.sMappingName + "\t" + ObjectTypeObject.sMappingName + "\t" + ObjectTypeObjectItem.sMappingName + "\t" + sSpecificObject + "\t" + YAMLArgument.sMappingName;
 
                     string sType = YAMLArgument.GetScalar("type");
-                    string sRange = YAMLArgument.GetScalar("range");
                     double dMin = YAMLArgument.GetScalar("min") != "" ? double.Parse(YAMLArgument.GetScalar("min")) : 0;
                     double dMax = YAMLArgument.GetScalar("max") != "" ? double.Parse(YAMLArgument.GetScalar("max")) : 0;
 
@@ -210,11 +209,11 @@ namespace nsRSMPGS
                       cYAMLMapping Values;
                       if (YAMLArgument.YAMLMappings.TryGetValue("values", out Values))
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, sRange, Values.YAMLScalars, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", Values.YAMLScalars, sDescription);
                       }
                       else
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, sRange, null, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", null, sDescription);
                       }
                       if (ValueTypeObjects.ContainsKey(sValueTypeKey))
                       {

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -1183,10 +1183,11 @@ namespace nsRSMPGS
           if (sRange.StartsWith("[") && sRange.EndsWith("]") && sRange.Contains("-"))
           {
             eValueType ValueType = eValueType._unknown;
-            foreach (ValueType in Enum.GetValues(typeof(eValueType)))
+            foreach (eValueType valueType in Enum.GetValues(typeof(eValueType)))
             {
-              if (sType.Equals(ValueType.ToString().Substring(1), StringComparison.OrdinalIgnoreCase))
+              if (sType.Equals(valueType.ToString().Substring(1), StringComparison.OrdinalIgnoreCase))
               {
+                ValueType = valueType;
                 break;
               }
             }

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -210,11 +210,11 @@ namespace nsRSMPGS
                       cYAMLMapping Values;
                       if (YAMLArgument.YAMLMappings.TryGetValue("values", out Values))
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", Values.YAMLScalars, dMin, dMax, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, Values.YAMLScalars, dMin, dMax, sDescription);
                       }
                       else
                       {
-                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, "", null, dMin, dMax, sDescription);
+                        ValueTypeObject = new cValueTypeObject(sValueTypeKey, YAMLArgument.sMappingName, sType, null, dMin, dMax, sDescription);
                       }
                       if (ValueTypeObjects.ContainsKey(sValueTypeKey))
                       {
@@ -1224,7 +1224,11 @@ namespace nsRSMPGS
               {
                 try
                 {
-                  eNums.Add(sValueItem.Substring(1), "");
+                  string sKey = sValueItem.Substring(1);
+                  if (eNums.ContainsKey(sKey) == false)
+                  { 
+                    eNums.Add(sValueItem.Substring(1), "");
+                  }
                 }
                 catch { }
               }
@@ -1236,7 +1240,7 @@ namespace nsRSMPGS
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Failed to parse value and range: {0}", sValueTypeKey.Replace("\t", "/"));
         }
 
-        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, sRange, eNums, dMin, dMax, sComment);
+        ValueTypeObject = new cValueTypeObject(sValueTypeKey, sName, sType, eNums, dMin, dMax, sComment);
 
         ValueTypeObjects.Add(sValueTypeKey, ValueTypeObject);
       }

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -489,7 +489,8 @@ namespace nsRSMPGS
                   CommandReturnValue.sCommand.Equals(CommandRequest_Value.cO, sc))
                 {
                   // Do some validation
-                  if (ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), CommandRequest_Value.v))
+                  if (ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), CommandRequest_Value.v, CommandReturnValue.Value.GetSelectableValues(),
+                    CommandReturnValue.Value.GetValueMin(), CommandReturnValue.Value.GetValueMax()))
                   {
                     if (CommandReturnValue.Value.GetValueType().Equals("base64", StringComparison.OrdinalIgnoreCase))
                     {

--- a/RSMPGS1/Settings/RSMPGS1.INI
+++ b/RSMPGS1/Settings/RSMPGS1.INI
@@ -64,11 +64,11 @@ BitText_6=Connected/normal - In Use
 BitText_7=Connected/normal - Idle
 BitText_8=Not Connected
 [Main]
-ObjectFilesTimeStamp=10214552
-LastSXLRevisionFromFile=1.0.15
+ObjectFilesTimeStamp=10797758
+LastSXLRevisionFromFile=1.1
 AlwaysShowGroupHeaders=0
-Left=55
-Top=474
+Left=144
+Top=319
 Width=1086
 Height=618
 ConnectAutomatically=0
@@ -77,7 +77,7 @@ AggregatedStatus_SendAutomaticallyWhenChanged=0
 DisableNagleAlgorithm=0
 SplitPackets=0
 StoreBase64Updates=0
-TabControl_Object=5
+TabControl_Object=4
 SignalExchangeListVersion=
 AlwaysUseSXLFromFile=0
 ViewOnlyFailedPackets=0
@@ -87,10 +87,11 @@ ProcessImageLoad_AlarmStatus=0
 ProcessImageLoad_AggregatedStatus=0
 ProcessImageLoad_Status=0
 AutomaticallyLoadObjects=1
-CSVObjectFilesPath=Objects\
-YAMLFileName=..\..\Objects
+CSVObjectFilesPath=C:\Program Files (x86)\RSMPGS1\Objects\
+YAMLFileName=C:\Program Files (x86)\RSMPGS1\YAML\SXL-example.yaml
 SelectedObjectFileType=0
 ShowMax10BufferedMessagesInSysLog=1
+SelectedObject=
 [Encryption]
 AuthenticateAsClientUsingCertificate=0
 CheckCertificateRevocationList=0
@@ -109,7 +110,7 @@ ClientCertificateFilePassword=
 [listView_SysLog]
 Severity.Width=25
 Time.Width=75
-Description.Width=880
+Description.Width=743
 [listView_Statistics]
 Description.Width=200
 Value.Width=100
@@ -168,6 +169,7 @@ Buffer10000Messages=0
 UseStrictProtocolAnalysis=0
 UseCaseSensitiveIds=0
 AllowRequestsOfAlarmsAndAggStatus=0
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_2]
 AllowUseRSMPVersion=1
 SendAggregatedStatusAtConnect=0
@@ -180,6 +182,7 @@ Buffer10000Messages=0
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
 AllowRequestsOfAlarmsAndAggStatus=0
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_3]
 AllowUseRSMPVersion=1
 SendAggregatedStatusAtConnect=1
@@ -192,6 +195,7 @@ Buffer10000Messages=0
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
 AllowRequestsOfAlarmsAndAggStatus=0
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_4]
 AllowUseRSMPVersion=1
 SendAggregatedStatusAtConnect=1
@@ -204,6 +208,7 @@ Buffer10000Messages=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
 AllowRequestsOfAlarmsAndAggStatus=0
+UseCaseSensitiveValue=0
 [Behaviour_Other]
 SendVersionInfoAtConnect=1
 SXL_VersionIgnore=0
@@ -229,10 +234,30 @@ BufferAndSendAggregatedStatusWhenConnect=1
 BufferAndSendStatusUpdatesWhenConnect=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
+UseCaseSensitiveValue=0
 [MostRecentObjectFiles]
-0=C:\DATA\C\RSMP\RSMPGS1\Objects\
-1=..\..\Objects\
+0=C:\Program Files (x86)\RSMPGS1\Objects\
+1=C:\Program Files (x86)\RSMPGS1\YAML\SXL-example.yaml
+2=C:\DATA\C\RSMP\RSMPGS1\Objects\
+3=..\..\Objects\
 [ListView_BufferedMessages]
 Type.Width=80
 Message id.Width=150
 JSon Packet data.Width=300
+[Behaviour_RSMP_3_2]
+AllowUseRSMPVersion=1
+ClearSubscriptionsAtDisconnect=0
+AllowRequestsOfAlarmsAndAggStatus=1
+Buffer10000Messages=1
+SendAggregatedStatusAtConnect=1
+SendAllAlarmsWhenConnect=1
+BufferAndSendAlarmsWhenConnect=1
+BufferAndSendAggregatedStatusWhenConnect=1
+BufferAndSendStatusUpdatesWhenConnect=1
+UseStrictProtocolAnalysis=1
+UseCaseSensitiveIds=1
+UseCaseSensitiveValue=1
+sWhenConnect=1
+UseStrictProtocolAnalysis=1
+UseCaseSensitiveIds=1
+UseCaseSensitiveValue=1

--- a/RSMPGS2/RSMPGS2_CommandForm.cs
+++ b/RSMPGS2/RSMPGS2_CommandForm.cs
@@ -33,34 +33,20 @@ namespace nsRSMPGS
         {
           bool bWasSelected = SelectedCRVs.IndexOf(CommandArguments) >= 0 ? true : false;
 
-          string[] aCommands;
+          string[] aCommands = {};
           if (CommandArguments.Value.ValueTypeObject.SelectableValues != null && CommandArguments.Value.ValueTypeObject.SelectableValues.Count > 0)
           {
             aCommands = CommandArguments.Value.ValueTypeObject.SelectableValues.Keys.ToArray<string>();
           }
-          else
-          {
-            aCommands = CommandArguments.Value.ValueTypeObject.sRange.Split('\n');
 
-            for (int j = 0; j < aCommands.Length; j++)
-            {
-              aCommands[j] = aCommands[j].TrimStart('"');
-              aCommands[j] = aCommands[j].TrimStart('-');
-              aCommands[j] = aCommands[j].TrimEnd('"');
-            }
-          }
-
-          // 
           if (CommandArguments.Value.GetValueType().Equals("boolean", StringComparison.OrdinalIgnoreCase))
           {
             // Create a selectable list of boolean elements if YAML format is used.
             // (If CSV format is used, it uses whatever defined in the "Values" column)
             if (aCommands.Length < 2)
             {
-              aCommands.Append("True");
-              aCommands.Append("False");
+              aCommands = new string[] { "True", "False" };
             }
- 
           }
 
           if ((CommandArguments.Value.ValueTypeObject.SelectableValues == null || CommandArguments.Value.ValueTypeObject.SelectableValues.Count == 0) && aCommands.Length < 2)

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -280,7 +280,7 @@ namespace nsRSMPGS
                     CommandReturnValue.sLastRecValue = Reply.v;
                     CommandReturnValue.sLastRecAge = Reply.age;
 
-                    if (ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), Reply.v))
+                    if (ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), Reply.v, CommandReturnValue.Value.GetSelectableValues(), CommandReturnValue.Value.GetValueMin(), CommandReturnValue.Value.GetValueMax()))
                     {
                       bSuccess = true;
                     }
@@ -369,7 +369,7 @@ namespace nsRSMPGS
           }
           StatusReturnValue.sQuality = Reply.q;
 
-          if (ValidateTypeAndRange(StatusReturnValue.Value.GetValueType(), Reply.s))
+          if (ValidateTypeAndRange(StatusReturnValue.Value.GetValueType(), Reply.s, StatusReturnValue.Value.GetSelectableValues(), StatusReturnValue.Value.GetValueMin(), StatusReturnValue.Value.GetValueMax()))
           {
             bSuccess = true;
           }

--- a/RSMPGS2/Settings/RSMPGS2.INI
+++ b/RSMPGS2/Settings/RSMPGS2.INI
@@ -80,29 +80,30 @@ BitText_7=Connected/normal - Not In Use
 BitText_8=Not Connected
 
 [Main]
-ObjectFilesTimeStamp=5437440
-LastSXLRevisionFromFile=1.0.15
+ObjectFilesTimeStamp=10797849
+LastSXLRevisionFromFile=1.1
 AlwaysShowGroupHeaders=0
-Left=100
-Top=156
-Width=1013
+Left=728
+Top=155
+Width=1205
 Height=817
 DisableNagleAlgorithm=0
 SplitPackets=0
 StoreBase64Updates=0
 ConnectAutomatically=0
 ShowTooltip=0
-TabControl_Object=5
+TabControl_Object=1
 SignalExchangeListVersion=
 AlwaysUseSXLFromFile=0
 AutomaticallyLoadObjects=1
 ViewOnlyFailedPackets=0
-CSVObjectFilesPath=Objects\
-YAMLFileName=C:\DATA\C\RSMP\RSMPGS2\Objects
+CSVObjectFilesPath=C:\Program Files (x86)\RSMPGS2\Objects\
+YAMLFileName=C:\Program Files (x86)\RSMPGS2\YAML\SXL-example.yaml
 SelectedObjectFileType=0
 SaveAsInitialDirectory=C:\DATA\C\RSMP\RSMPGS2
 SaveAsFileName=
 LoadProcessImageAtStartUp=0
+SelectedObject=
 [Encryption]
 AuthenticateAsClientUsingCertificate=0
 CheckCertificateRevocationList=0
@@ -122,22 +123,27 @@ ClientCertificateFilePassword=
 AllowUseRSMPVersion=1
 UseStrictProtocolAnalysis=0
 UseCaseSensitiveIds=0
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_2]
 AllowUseRSMPVersion=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_3]
 AllowUseRSMPVersion=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_4]
 AllowUseRSMPVersion=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
+UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_5]
 AllowUseRSMPVersion=1
 UseStrictProtocolAnalysis=1
 UseCaseSensitiveIds=1
+UseCaseSensitiveValue=0
 [Behaviour_Other]
 SendVersionInfoAtConnect=1
 SXL_VersionIgnore=0
@@ -152,11 +158,14 @@ SendWatchdogPacketCyclically=1
 ExpectWatchdogPackets=1
 UseEncryption=0
 [MostRecentObjectFiles]
-0=C:\DATA\C\RSMP\RSMPGS2\Objects\
+0=C:\Program Files (x86)\RSMPGS2\Objects\
+1=C:\Program Files (x86)\RSMPGS1\Objects\
+2=C:\Program Files (x86)\RSMPGS2\YAML\SXL-example.yaml
+3=C:\DATA\C\RSMP\RSMPGS2\Objects\
 [listView_SysLog]
 Severity.Width=25
 Time.Width=75
-Description.Width=738
+Description.Width=743
 [listView_Statistics]
 Description.Width=200
 Value.Width=100
@@ -230,3 +239,8 @@ Name.Width=60
 Command.Width=99
 Value.Width=60
 Age.Width=60
+[Behaviour_RSMP_3_2]
+AllowUseRSMPVersion=1
+UseStrictProtocolAnalysis=1
+UseCaseSensitiveIds=1
+UseCaseSensitiveValue=1


### PR DESCRIPTION
Add option for checking case sensitive in values.

RSMP 3.2 requires everything to be case sensitive. Previously the RSMP simulator included options to enable/disable case sensitive check (using "Use case sensitive lookup for object id's and references") for parts of the communication, which included:
- componentId
- statusCodeId (perhpas alarmCodeId and commandCodeId as well)
- "name" in argument/return values

But not for the return values of statuses and alarms or the arguments of commands. This PR adds an option for this.

Remaining issues:
- [x] Only validates 'boolean'. Needs to check enum, min and max too
- [x]  Expects boolean to be sent as "true" and "false", even when SXL defines otherwise, e.g. "True", "False" (only applies to Excel/CSV). How boolean should be treated may need clarification in core. Needs verification for alarms and statuses too.
- [x] Update documentation