### PR TITLE
RSMPGS2: Improve validation of messages

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -187,6 +187,12 @@ namespace nsRSMPGS
 #if _RSMPGS2
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.AlarmHeaderAndBody), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "Alarm", ref sError);
+
+              // Validate the return value, but only if defined
+              if (bSuccess && !(sJSon.Replace(" ", "").IndexOf("\"rvs\":[]", StringComparison.Ordinal) > 0))
+              {
+                bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.AlarmReturnValue), sJSon, ref sError);
+              }
 #endif
 #if _RSMPGS1
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.AlarmHeader), sJSon, ref sError) &&
@@ -211,6 +217,7 @@ namespace nsRSMPGS
             case "commandrequest":
 
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.CommandRequest), sJSon, ref sError) &&
+                ValidateJSONProperties(typeof(RSMP_Messages.CommandRequest_Value), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "CommandRequest", ref sError);
 
               break;
@@ -218,6 +225,7 @@ namespace nsRSMPGS
             case "commandresponse":
 
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.CommandResponse), sJSon, ref sError) &&
+                ValidateJSONProperties(typeof(RSMP_Messages.CommandResponse_Value), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "CommandResponse", ref sError);
 
               break;
@@ -225,6 +233,7 @@ namespace nsRSMPGS
             case "statusrequest":
 
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.StatusRequest), sJSon, ref sError) &&
+                ValidateJSONProperties(typeof(RSMP_Messages.StatusRequest_Status), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "StatusRequest", ref sError);
 
               break;
@@ -253,6 +262,7 @@ namespace nsRSMPGS
             case "statusresponse":
 
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.StatusResponse), sJSon, ref sError) &&
+                ValidateJSONProperties(typeof(RSMP_Messages.Status_VTQ), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "StatusResponse", ref sError);
 
               break;
@@ -946,6 +956,8 @@ namespace nsRSMPGS
       // Pack to ensure there is no space between "Tag" and ':'
       sJSon = sJSon.Replace(" ", "");
 
+
+      // When this is used to test return values, only the first occurence is tested
       foreach (FieldInfo field in fields)
       {
         // Ugly stuff to find out if the field exists and has bad casing

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -98,7 +98,7 @@ namespace nsRSMPGS
         cRoadSideObject RoadSideObject = cHelper.FindRoadSideObject(AlarmHeader.ntsOId, AlarmHeader.cId, bUseCaseSensitiveIds);
         if (RoadSideObject == null)
         {
-          sError = "Failed to handle Alarm message, could not find object, ntsOId: " + AlarmHeader.ntsOId + ", cId: " + AlarmHeader.cId + ", aCId: " + AlarmHeader.aCId;
+          sError = "Failed to handle Alarm message, could not find object, ntsOId: `" + AlarmHeader.ntsOId + "´, cId: `" + AlarmHeader.cId + "´, aCId: `" + AlarmHeader.aCId + "´";
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
           return false;
         }
@@ -106,21 +106,21 @@ namespace nsRSMPGS
         cAlarmObject AlarmObject = RoadSideObject.AlarmObjects.Find(x => x.sAlarmCodeId.Equals(AlarmHeader.aCId, sc));
         if (AlarmObject == null)
         {
-          sError = "Failed to handle Alarm message, could not find alarm code id, ntsOId: " + AlarmHeader.ntsOId + ", cId: " + AlarmHeader.cId + ", aCId: " + AlarmHeader.aCId;
+          sError = "Failed to handle Alarm message, could not find alarm code id, ntsOId: `" + AlarmHeader.ntsOId + "´, cId: `" + AlarmHeader.cId + "´, aCId: `" + AlarmHeader.aCId + "´";
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
           return false;
         }
 
         if (AlarmObject.sPriority != AlarmHeader.pri)
         {
-          sError = "Failed to handle Alarm message. Priority (pri) mismatch, pri: " + AlarmHeader.pri;
+          sError = "Failed to handle Alarm message. Priority (pri) mismatch, pri: `" + AlarmHeader.pri + "´";
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
           return false;
         }
 
         if (AlarmObject.sCategory != AlarmHeader.cat)
         {
-          sError = "Failed to handle Alarm message. Category (cat) mismatch, cat: " + AlarmHeader.cat;
+          sError = "Failed to handle Alarm message. Category (cat) mismatch, cat: `" + AlarmHeader.cat + "´";
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
           return false;
         }
@@ -139,7 +139,7 @@ namespace nsRSMPGS
             cAlarmReturnValue AlarmReturnValue = AlarmObject.AlarmReturnValues.Find(x => x.sName.Equals(Reply.n, sc));
             if (AlarmReturnValue == null)
             {
-              sError = "Failed to handle Alarm message. Failed to find name, n: " + Reply.n;
+              sError = "Failed to handle Alarm message. Failed to find name, n: `" + Reply.n + "´";
               RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
               return false;
             }
@@ -162,77 +162,77 @@ namespace nsRSMPGS
               {
                 sReturnValue = (Reply.v.Length < 10) ? Reply.v : Reply.v.Substring(0, 9) + "...";
               }
-              sError = "Value and/or type is out of range or invalid for this RSMP protocol version, type: " + AlarmReturnValue.Value.GetValueType() + ", returnvalue: " + sReturnValue;
+              sError = "Value and/or type is out of range or invalid for this RSMP protocol version, type: `" + AlarmReturnValue.Value.GetValueType() + "´, returnvalue: `" + sReturnValue + "´";
               RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
               return false;
             }
           }
         }
 
-        switch (AlarmHeader.aSp.ToLower())
+        switch (AlarmHeader.aSp)
         {
-          case "issue":
+          case var name when string.Equals(name, "Issue", sc):
             AlarmEvent.sEvent = AlarmHeader.aSp + " / " + AlarmHeader.aS;
             if (AlarmHeader.aS.Equals("active", StringComparison.OrdinalIgnoreCase))
             {
               AlarmObject.AlarmCount++;
             }
             break;
-          case "acknowledge":
+          case var name when string.Equals(name, "Acknowledge", sc):
             AlarmEvent.sEvent = AlarmHeader.aSp + " / " + AlarmHeader.ack;
             break;
-          case "suspend":
+          case var name when string.Equals(name, "Suspend", sc):
             AlarmEvent.sEvent = AlarmHeader.aSp + " / " + AlarmHeader.sS;
             break;
           default:
             AlarmEvent.sEvent = "(unknown: " + AlarmHeader.aSp + ")";
-            sError = "Could not parse correct alarm state " + AlarmHeader.aSp + " (corresponding MsgId " + AlarmHeader.mId + ")";
+            sError = "Could not parse correct alarm state `" + AlarmHeader.aSp + "´ (corresponding MsgId " + AlarmHeader.mId + ")";
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
             return false;
         }
 
-        switch (AlarmHeader.aS.ToLower())
+        switch (AlarmHeader.aS)
         {
-          case "active":
+          case var name when string.Equals(name, "Active", sc):
             AlarmObject.bActive = true;
             break;
-          case "inactive":
+          case var name when string.Equals(name, "inActive", sc):
             AlarmObject.bActive = false;
             break;
           default:
             AlarmEvent.sEvent = "(unknown: " + AlarmHeader.aS + ")";
-            sError = "Could not parse correct alarm state " + AlarmHeader.sS + " (corresponding MsgId " + AlarmHeader.mId + ")";
+            sError = "Could not parse correct alarm state `" + AlarmHeader.aS + "´ (corresponding MsgId " + AlarmHeader.mId + ")";
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
             return false;
         }
 
-        switch (AlarmHeader.ack.ToLower())
+        switch (AlarmHeader.ack)
         {
-          case "acknowledged":
+          case var name when string.Equals(name, "Acknowledged", sc):
             AlarmObject.bAcknowledged = true;
             break;
-          case "notacknowledged":
+          case var name when string.Equals(name, "notAcknowledged", sc):
             AlarmObject.bAcknowledged = false;
             break;
           default:
             AlarmEvent.sEvent = "(unknown: " + AlarmHeader.ack + ")";
-            sError = "Could not parse correct alarm state " + AlarmHeader.ack + " (corresponding MsgId " + AlarmHeader.mId + ")";
+            sError = "Could not parse correct alarm state `" + AlarmHeader.ack + "´ (corresponding MsgId " + AlarmHeader.mId + ")";
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
             return false;
         }
 
-        switch (AlarmHeader.sS.ToLower())
+        switch (AlarmHeader.sS)
         {
-          case "suspended":
+          case var name when string.Equals(name, "Suspended", sc):
             AlarmObject.bSuspended = true;
             break;
-          case "notsuspended":
+          case var name when string.Equals(name, "notSuspended", sc):
             AlarmObject.bSuspended = false;
             break;
           default:
             AlarmEvent.sEvent = "(unknown: " + AlarmHeader.sS + ")";
-            RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Could not parse correct alarm state {0} (corresponding MsgId {1}) ",
-              AlarmHeader.sS, AlarmHeader.mId);
+            sError = "Could not parse correct alarm state `" + AlarmHeader.sS + "´ (corresponding MsgId " + AlarmHeader.mId + ")";
+            RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
             return false;
         }
 

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -113,6 +113,10 @@ namespace nsRSMPGS
           return false;
         }
 
+        // Previosly, RSMPGS2 considered alarm messages which didn't contain 'cat' to orignate from
+        // SCADA. This resulted in not performing any validation, writing to syslog and returning true.
+        // RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Info, "Got alarm message from SCADA, aSp: {0} (corresponding MsgId {1}) ", AlarmHeader.aSp, AlarmHeader.mId);
+
         if (AlarmObject.sPriority != AlarmHeader.pri)
         {
           sError = "Failed to handle Alarm message. Priority (pri) mismatch, pri: `" + AlarmHeader.pri + "´";
@@ -245,8 +249,6 @@ namespace nsRSMPGS
         RSMPGS.MainForm.AddAlarmEventToAlarmObjectAndToList(AlarmObject, AlarmEvent);
         RSMPGS.MainForm.UpdateAlarmListView(AlarmObject);
 
-        RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Info, "Got alarm message from SCADA, aSp: {0} (corresponding MsgId {1}) ",
-          AlarmHeader.aSp, AlarmHeader.mId);
       }
       catch (Exception e)
       {

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -462,7 +462,7 @@ namespace nsRSMPGS
           }
 
           StatusReturnValue.sQuality = Reply.q;
-          if(!Enum.IsDefined(typeof(cValue.eQuality), StatusReturnValue.sQuality))
+          if (!Enum.GetNames(typeof(cValue.eQuality)).Any(x => x.Equals(StatusReturnValue.sQuality, sc)))
           {
             sError = "Failed to handle Status message. Failed to find quality, q: `" + Reply.q + "´";
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);


### PR DESCRIPTION
- Not all messages are properly validated case sensitive (if selected)
- In some cases there are missing validation of parts of messages 

TODO:
- [x] RSMPGS2: Validate all fields of the alarm, status and commands messages.
- [x] RSMPGS2 doesn't check casing of the element names in the return values (command: cCi, n, age, v, statuses: sCI, n, s, q)
- [x] Doesn't handle age=unknown correctly
- [x] Check RSMPGS1