### PR TITLE
Use correct SXL metadata for the YAML examples

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,7 +13,9 @@ env:
   SXL: rsmp_schema/schemas/tlc/1.2/sxl.yaml
   SXL_1_1: rsmp_schema/schemas/tlc/1.1/sxl.yaml
   SXL_1_0_15: rsmp_schema/schemas/tlc/1.0.15/sxl.yaml
-  SITE: sxl-tools/tlc/SXL_Traffic_Controller_ver_1_1-site.yaml
+  SITE: YAML/SXL_Traffic_Controller_ver_1_2-site.yaml
+  SITE_1_1: YAML/SXL_Traffic_Controller_ver_1_1-site.yaml
+  SITE_1_0_15: YAML/SXL_Traffic_Controller_ver_1_0_15-site.yaml
 
 jobs:
   create_sxl:
@@ -38,6 +40,9 @@ jobs:
 
       - name: Install ruby dependencies
         run: gem install rubyXL
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Checkout sxl-tools
         uses: actions/checkout@v3

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -85,8 +85,8 @@ jobs:
           #   The first format is not supported by the simulator.
           ruby sxl-tools/merge_yaml.rb --objects $SXL --site $SITE > TLC_SXL_1_2.yaml
           # Also include older SXL files
-          ruby sxl-tools/merge_yaml.rb --objects $SXL_1_1 --site $SITE > TLC_SXL_1_1.yaml
-          ruby sxl-tools/merge_yaml.rb --objects $SXL_1_0_15 --site $SITE > TLC_SXL_1_0_15.yaml
+          ruby sxl-tools/merge_yaml.rb --objects $SXL_1_1 --site $SITE_1_1 > TLC_SXL_1_1.yaml
+          ruby sxl-tools/merge_yaml.rb --objects $SXL_1_0_15 --site $SITE_1_0_15 > TLC_SXL_1_0_15.yaml
 
       - name: Upload artifacts (XLSX)
         uses: actions/upload-artifact@v3

--- a/YAML/SXL_Traffic_Controller_ver_1_0_15-site.yaml
+++ b/YAML/SXL_Traffic_Controller_ver_1_0_15-site.yaml
@@ -1,0 +1,1549 @@
+---
+id: Plant id
+version: '1.0.15'
+date: '2020-10-30'
+description: Plant name
+constructor: RSMP Nordic
+created-date: '2010-04-20'
+rsmp-version: '3.1.5'
+objects:
+sites:
+  AA+BBCC:
+    description: Anl. ??
+    objects:
+      Traffic Light Controller:
+        Traffic Light Controller:
+          componentId: AA+BBCCC=DDDEEFFF
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Signal group:
+        SG1:
+          componentId: AA+BBCCC=DDDEEFF1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG2:
+          componentId: AA+BBCCC=DDDEEFF2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG3:
+          componentId: AA+BBCCC=DDDEEFF3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG4:
+          componentId: AA+BBCCC=DDDEEFF4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG5:
+          componentId: AA+BBCCC=DDDEEFF5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG6:
+          componentId: AA+BBCCC=DDDEEFF6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG7:
+          componentId: AA+BBCCC=DDDEEFF7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG8:
+          componentId: AA+BBCCC=DDDEEFF8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG9:
+          componentId: AA+BBCCC=DDDEEFF9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG10:
+          componentId: AA+BBCCC=DDDEEF10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG11:
+          componentId: AA+BBCCC=DDDEEF11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG12:
+          componentId: AA+BBCCC=DDDEEF12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG13:
+          componentId: AA+BBCCC=DDDEEF13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG14:
+          componentId: AA+BBCCC=DDDEEF14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG15:
+          componentId: AA+BBCCC=DDDEEF15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG16:
+          componentId: AA+BBCCC=DDDEEF16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG17:
+          componentId: AA+BBCCC=DDDEEF17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG18:
+          componentId: AA+BBCCC=DDDEEF18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG19:
+          componentId: AA+BBCCC=DDDEEF19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG20:
+          componentId: AA+BBCCC=DDDEEF20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG21:
+          componentId: AA+BBCCC=DDDEEF21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG22:
+          componentId: AA+BBCCC=DDDEEF22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG23:
+          componentId: AA+BBCCC=DDDEEF23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG24:
+          componentId: AA+BBCCC=DDDEEF24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG25:
+          componentId: AA+BBCCC=DDDEEF25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG26:
+          componentId: AA+BBCCC=DDDEEF26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG27:
+          componentId: AA+BBCCC=DDDEEF27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG28:
+          componentId: AA+BBCCC=DDDEEF28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG29:
+          componentId: AA+BBCCC=DDDEEF29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG30:
+          componentId: AA+BBCCC=DDDEEF30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG31:
+          componentId: AA+BBCCC=DDDEEF31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG32:
+          componentId: AA+BBCCC=DDDEEF32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG33:
+          componentId: AA+BBCCC=DDDEEF33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG34:
+          componentId: AA+BBCCC=DDDEEF34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG35:
+          componentId: AA+BBCCC=DDDEEF35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG36:
+          componentId: AA+BBCCC=DDDEEF36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG37:
+          componentId: AA+BBCCC=DDDEEF37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG38:
+          componentId: AA+BBCCC=DDDEEF38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG39:
+          componentId: AA+BBCCC=DDDEEF39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG40:
+          componentId: AA+BBCCC=DDDEEF40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG41:
+          componentId: AA+BBCCC=DDDEEF41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG42:
+          componentId: AA+BBCCC=DDDEEF42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG43:
+          componentId: AA+BBCCC=DDDEEF43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG44:
+          componentId: AA+BBCCC=DDDEEF44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG45:
+          componentId: AA+BBCCC=DDDEEF45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG46:
+          componentId: AA+BBCCC=DDDEEF46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG47:
+          componentId: AA+BBCCC=DDDEEF47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG48:
+          componentId: AA+BBCCC=DDDEEF48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG49:
+          componentId: AA+BBCCC=DDDEEF49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG50:
+          componentId: AA+BBCCC=DDDEEF50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG51:
+          componentId: AA+BBCCC=DDDEEF51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG52:
+          componentId: AA+BBCCC=DDDEEF52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG53:
+          componentId: AA+BBCCC=DDDEEF53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG54:
+          componentId: AA+BBCCC=DDDEEF54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG55:
+          componentId: AA+BBCCC=DDDEEF55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG56:
+          componentId: AA+BBCCC=DDDEEF56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG57:
+          componentId: AA+BBCCC=DDDEEF57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG58:
+          componentId: AA+BBCCC=DDDEEF58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG59:
+          componentId: AA+BBCCC=DDDEEF59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG60:
+          componentId: AA+BBCCC=DDDEEF60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG61:
+          componentId: AA+BBCCC=DDDEEF61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG62:
+          componentId: AA+BBCCC=DDDEEF62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG63:
+          componentId: AA+BBCCC=DDDEEF63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG64:
+          componentId: AA+BBCCC=DDDEEF64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG65:
+          componentId: AA+BBCCC=DDDEEF65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG66:
+          componentId: AA+BBCCC=DDDEEF66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG67:
+          componentId: AA+BBCCC=DDDEEF67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG68:
+          componentId: AA+BBCCC=DDDEEF68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG69:
+          componentId: AA+BBCCC=DDDEEF69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG70:
+          componentId: AA+BBCCC=DDDEEF70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG71:
+          componentId: AA+BBCCC=DDDEEF71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG72:
+          componentId: AA+BBCCC=DDDEEF72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG73:
+          componentId: AA+BBCCC=DDDEEF73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG74:
+          componentId: AA+BBCCC=DDDEEF74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG75:
+          componentId: AA+BBCCC=DDDEEF75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG76:
+          componentId: AA+BBCCC=DDDEEF76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG77:
+          componentId: AA+BBCCC=DDDEEF77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG78:
+          componentId: AA+BBCCC=DDDEEF78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG79:
+          componentId: AA+BBCCC=DDDEEF79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG80:
+          componentId: AA+BBCCC=DDDEEF80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG81:
+          componentId: AA+BBCCC=DDDEEF81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG82:
+          componentId: AA+BBCCC=DDDEEF82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG83:
+          componentId: AA+BBCCC=DDDEEF83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG84:
+          componentId: AA+BBCCC=DDDEEF84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG85:
+          componentId: AA+BBCCC=DDDEEF85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG86:
+          componentId: AA+BBCCC=DDDEEF86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG87:
+          componentId: AA+BBCCC=DDDEEF87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG88:
+          componentId: AA+BBCCC=DDDEEF88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG89:
+          componentId: AA+BBCCC=DDDEEF89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG90:
+          componentId: AA+BBCCC=DDDEEF90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG91:
+          componentId: AA+BBCCC=DDDEEF91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG92:
+          componentId: AA+BBCCC=DDDEEF92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG93:
+          componentId: AA+BBCCC=DDDEEF93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG94:
+          componentId: AA+BBCCC=DDDEEF94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG95:
+          componentId: AA+BBCCC=DDDEEF95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG96:
+          componentId: AA+BBCCC=DDDEEF96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG97:
+          componentId: AA+BBCCC=DDDEEF97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG98:
+          componentId: AA+BBCCC=DDDEEF98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG99:
+          componentId: AA+BBCCC=DDDEEF99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG100:
+          componentId: AA+BBCCC=DDDEE100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG101:
+          componentId: AA+BBCCC=DDDEE101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG102:
+          componentId: AA+BBCCC=DDDEE102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG103:
+          componentId: AA+BBCCC=DDDEE103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG104:
+          componentId: AA+BBCCC=DDDEE104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG105:
+          componentId: AA+BBCCC=DDDEE105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG106:
+          componentId: AA+BBCCC=DDDEE106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG107:
+          componentId: AA+BBCCC=DDDEE107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG108:
+          componentId: AA+BBCCC=DDDEE108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG109:
+          componentId: AA+BBCCC=DDDEE109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG110:
+          componentId: AA+BBCCC=DDDEE110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG111:
+          componentId: AA+BBCCC=DDDEE111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG112:
+          componentId: AA+BBCCC=DDDEE112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG113:
+          componentId: AA+BBCCC=DDDEE113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG114:
+          componentId: AA+BBCCC=DDDEE114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG115:
+          componentId: AA+BBCCC=DDDEE115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG116:
+          componentId: AA+BBCCC=DDDEE116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG117:
+          componentId: AA+BBCCC=DDDEE117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG118:
+          componentId: AA+BBCCC=DDDEE118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG119:
+          componentId: AA+BBCCC=DDDEE119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG120:
+          componentId: AA+BBCCC=DDDEE120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG121:
+          componentId: AA+BBCCC=DDDEE121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG122:
+          componentId: AA+BBCCC=DDDEE122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG123:
+          componentId: AA+BBCCC=DDDEE123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG124:
+          componentId: AA+BBCCC=DDDEE124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG125:
+          componentId: AA+BBCCC=DDDEE125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG126:
+          componentId: AA+BBCCC=DDDEE126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG127:
+          componentId: AA+BBCCC=DDDEE127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG128:
+          componentId: AA+BBCCC=DDDEE128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG129:
+          componentId: AA+BBCCC=DDDEE129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG130:
+          componentId: AA+BBCCC=DDDEE130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG131:
+          componentId: AA+BBCCC=DDDEE131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG132:
+          componentId: AA+BBCCC=DDDEE132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG133:
+          componentId: AA+BBCCC=DDDEE133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG134:
+          componentId: AA+BBCCC=DDDEE134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG135:
+          componentId: AA+BBCCC=DDDEE135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG136:
+          componentId: AA+BBCCC=DDDEE136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG137:
+          componentId: AA+BBCCC=DDDEE137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG138:
+          componentId: AA+BBCCC=DDDEE138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG139:
+          componentId: AA+BBCCC=DDDEE139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG140:
+          componentId: AA+BBCCC=DDDEE140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG141:
+          componentId: AA+BBCCC=DDDEE141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG142:
+          componentId: AA+BBCCC=DDDEE142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG143:
+          componentId: AA+BBCCC=DDDEE143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG144:
+          componentId: AA+BBCCC=DDDEE144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG145:
+          componentId: AA+BBCCC=DDDEE145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG146:
+          componentId: AA+BBCCC=DDDEE146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG147:
+          componentId: AA+BBCCC=DDDEE147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG148:
+          componentId: AA+BBCCC=DDDEE148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG149:
+          componentId: AA+BBCCC=DDDEE149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG150:
+          componentId: AA+BBCCC=DDDEE150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG151:
+          componentId: AA+BBCCC=DDDEE151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG152:
+          componentId: AA+BBCCC=DDDEE152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG153:
+          componentId: AA+BBCCC=DDDEE153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG154:
+          componentId: AA+BBCCC=DDDEE154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG155:
+          componentId: AA+BBCCC=DDDEE155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG156:
+          componentId: AA+BBCCC=DDDEE156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG157:
+          componentId: AA+BBCCC=DDDEE157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG158:
+          componentId: AA+BBCCC=DDDEE158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG159:
+          componentId: AA+BBCCC=DDDEE159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG160:
+          componentId: AA+BBCCC=DDDEE160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG161:
+          componentId: AA+BBCCC=DDDEE161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG162:
+          componentId: AA+BBCCC=DDDEE162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG163:
+          componentId: AA+BBCCC=DDDEE163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG164:
+          componentId: AA+BBCCC=DDDEE164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG165:
+          componentId: AA+BBCCC=DDDEE165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG166:
+          componentId: AA+BBCCC=DDDEE166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG167:
+          componentId: AA+BBCCC=DDDEE167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG168:
+          componentId: AA+BBCCC=DDDEE168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG169:
+          componentId: AA+BBCCC=DDDEE169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG170:
+          componentId: AA+BBCCC=DDDEE170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG171:
+          componentId: AA+BBCCC=DDDEE171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG172:
+          componentId: AA+BBCCC=DDDEE172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG173:
+          componentId: AA+BBCCC=DDDEE173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG174:
+          componentId: AA+BBCCC=DDDEE174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG175:
+          componentId: AA+BBCCC=DDDEE175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG176:
+          componentId: AA+BBCCC=DDDEE176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG177:
+          componentId: AA+BBCCC=DDDEE177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG178:
+          componentId: AA+BBCCC=DDDEE178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG179:
+          componentId: AA+BBCCC=DDDEE179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG180:
+          componentId: AA+BBCCC=DDDEE180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG181:
+          componentId: AA+BBCCC=DDDEE181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG182:
+          componentId: AA+BBCCC=DDDEE182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG183:
+          componentId: AA+BBCCC=DDDEE183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG184:
+          componentId: AA+BBCCC=DDDEE184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG185:
+          componentId: AA+BBCCC=DDDEE185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG186:
+          componentId: AA+BBCCC=DDDEE186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG187:
+          componentId: AA+BBCCC=DDDEE187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG188:
+          componentId: AA+BBCCC=DDDEE188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG189:
+          componentId: AA+BBCCC=DDDEE189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG190:
+          componentId: AA+BBCCC=DDDEE190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG191:
+          componentId: AA+BBCCC=DDDEE191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG192:
+          componentId: AA+BBCCC=DDDEE192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG193:
+          componentId: AA+BBCCC=DDDEE193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG194:
+          componentId: AA+BBCCC=DDDEE194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG195:
+          componentId: AA+BBCCC=DDDEE195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG196:
+          componentId: AA+BBCCC=DDDEE196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG197:
+          componentId: AA+BBCCC=DDDEE197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG198:
+          componentId: AA+BBCCC=DDDEE198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG199:
+          componentId: AA+BBCCC=DDDEE199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG200:
+          componentId: AA+BBCCC=DDDEE200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG201:
+          componentId: AA+BBCCC=DDDEE201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG202:
+          componentId: AA+BBCCC=DDDEE202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG203:
+          componentId: AA+BBCCC=DDDEE203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG204:
+          componentId: AA+BBCCC=DDDEE204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG205:
+          componentId: AA+BBCCC=DDDEE205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG206:
+          componentId: AA+BBCCC=DDDEE206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG207:
+          componentId: AA+BBCCC=DDDEE207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG208:
+          componentId: AA+BBCCC=DDDEE208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG209:
+          componentId: AA+BBCCC=DDDEE209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG210:
+          componentId: AA+BBCCC=DDDEE210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG211:
+          componentId: AA+BBCCC=DDDEE211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG212:
+          componentId: AA+BBCCC=DDDEE212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG213:
+          componentId: AA+BBCCC=DDDEE213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG214:
+          componentId: AA+BBCCC=DDDEE214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG215:
+          componentId: AA+BBCCC=DDDEE215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG216:
+          componentId: AA+BBCCC=DDDEE216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG217:
+          componentId: AA+BBCCC=DDDEE217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG218:
+          componentId: AA+BBCCC=DDDEE218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG219:
+          componentId: AA+BBCCC=DDDEE219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG220:
+          componentId: AA+BBCCC=DDDEE220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG221:
+          componentId: AA+BBCCC=DDDEE221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG222:
+          componentId: AA+BBCCC=DDDEE222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG223:
+          componentId: AA+BBCCC=DDDEE223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG224:
+          componentId: AA+BBCCC=DDDEE224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG225:
+          componentId: AA+BBCCC=DDDEE225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG226:
+          componentId: AA+BBCCC=DDDEE226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG227:
+          componentId: AA+BBCCC=DDDEE227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG228:
+          componentId: AA+BBCCC=DDDEE228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG229:
+          componentId: AA+BBCCC=DDDEE229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG230:
+          componentId: AA+BBCCC=DDDEE230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG231:
+          componentId: AA+BBCCC=DDDEE231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG232:
+          componentId: AA+BBCCC=DDDEE232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG233:
+          componentId: AA+BBCCC=DDDEE233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG234:
+          componentId: AA+BBCCC=DDDEE234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG235:
+          componentId: AA+BBCCC=DDDEE235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG236:
+          componentId: AA+BBCCC=DDDEE236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG237:
+          componentId: AA+BBCCC=DDDEE237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG238:
+          componentId: AA+BBCCC=DDDEE238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG239:
+          componentId: AA+BBCCC=DDDEE239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG240:
+          componentId: AA+BBCCC=DDDEE240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG241:
+          componentId: AA+BBCCC=DDDEE241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG242:
+          componentId: AA+BBCCC=DDDEE242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG243:
+          componentId: AA+BBCCC=DDDEE243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG244:
+          componentId: AA+BBCCC=DDDEE244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG245:
+          componentId: AA+BBCCC=DDDEE245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG246:
+          componentId: AA+BBCCC=DDDEE246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG247:
+          componentId: AA+BBCCC=DDDEE247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG248:
+          componentId: AA+BBCCC=DDDEE248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG249:
+          componentId: AA+BBCCC=DDDEE249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG250:
+          componentId: AA+BBCCC=DDDEE250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG251:
+          componentId: AA+BBCCC=DDDEE251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG252:
+          componentId: AA+BBCCC=DDDEE252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG253:
+          componentId: AA+BBCCC=DDDEE253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG254:
+          componentId: AA+BBCCC=DDDEE254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG255:
+          componentId: AA+BBCCC=DDDEE255
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Detector logic:
+        DL1:
+          componentId: AA+BBCCC=DDDDLAA1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL2:
+          componentId: AA+BBCCC=DDDDLAA2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL3:
+          componentId: AA+BBCCC=DDDDLAA3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL4:
+          componentId: AA+BBCCC=DDDDLAA4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL5:
+          componentId: AA+BBCCC=DDDDLAA5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL6:
+          componentId: AA+BBCCC=DDDDLAA6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL7:
+          componentId: AA+BBCCC=DDDDLAA7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL8:
+          componentId: AA+BBCCC=DDDDLAA8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL9:
+          componentId: AA+BBCCC=DDDDLAA9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL10:
+          componentId: AA+BBCCC=DDDDLA10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL11:
+          componentId: AA+BBCCC=DDDDLA11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL12:
+          componentId: AA+BBCCC=DDDDLA12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL13:
+          componentId: AA+BBCCC=DDDDLA13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL14:
+          componentId: AA+BBCCC=DDDDLA14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL15:
+          componentId: AA+BBCCC=DDDDLA15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL16:
+          componentId: AA+BBCCC=DDDDLA16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL17:
+          componentId: AA+BBCCC=DDDDLA17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL18:
+          componentId: AA+BBCCC=DDDDLA18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL19:
+          componentId: AA+BBCCC=DDDDLA19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL20:
+          componentId: AA+BBCCC=DDDDLA20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL21:
+          componentId: AA+BBCCC=DDDDLA21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL22:
+          componentId: AA+BBCCC=DDDDLA22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL23:
+          componentId: AA+BBCCC=DDDDLA23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL24:
+          componentId: AA+BBCCC=DDDDLA24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL25:
+          componentId: AA+BBCCC=DDDDLA25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL26:
+          componentId: AA+BBCCC=DDDDLA26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL27:
+          componentId: AA+BBCCC=DDDDLA27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL28:
+          componentId: AA+BBCCC=DDDDLA28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL29:
+          componentId: AA+BBCCC=DDDDLA29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL30:
+          componentId: AA+BBCCC=DDDDLA30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL31:
+          componentId: AA+BBCCC=DDDDLA31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL32:
+          componentId: AA+BBCCC=DDDDLA32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL33:
+          componentId: AA+BBCCC=DDDDLA33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL34:
+          componentId: AA+BBCCC=DDDDLA34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL35:
+          componentId: AA+BBCCC=DDDDLA35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL36:
+          componentId: AA+BBCCC=DDDDLA36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL37:
+          componentId: AA+BBCCC=DDDDLA37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL38:
+          componentId: AA+BBCCC=DDDDLA38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL39:
+          componentId: AA+BBCCC=DDDDLA39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL40:
+          componentId: AA+BBCCC=DDDDLA40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL41:
+          componentId: AA+BBCCC=DDDDLA41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL42:
+          componentId: AA+BBCCC=DDDDLA42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL43:
+          componentId: AA+BBCCC=DDDDLA43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL44:
+          componentId: AA+BBCCC=DDDDLA44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL45:
+          componentId: AA+BBCCC=DDDDLA45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL46:
+          componentId: AA+BBCCC=DDDDLA46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL47:
+          componentId: AA+BBCCC=DDDDLA47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL48:
+          componentId: AA+BBCCC=DDDDLA48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL49:
+          componentId: AA+BBCCC=DDDDLA49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL50:
+          componentId: AA+BBCCC=DDDDLA50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL51:
+          componentId: AA+BBCCC=DDDDLA51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL52:
+          componentId: AA+BBCCC=DDDDLA52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL53:
+          componentId: AA+BBCCC=DDDDLA53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL54:
+          componentId: AA+BBCCC=DDDDLA54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL55:
+          componentId: AA+BBCCC=DDDDLA55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL56:
+          componentId: AA+BBCCC=DDDDLA56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL57:
+          componentId: AA+BBCCC=DDDDLA57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL58:
+          componentId: AA+BBCCC=DDDDLA58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL59:
+          componentId: AA+BBCCC=DDDDLA59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL60:
+          componentId: AA+BBCCC=DDDDLA60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL61:
+          componentId: AA+BBCCC=DDDDLA61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL62:
+          componentId: AA+BBCCC=DDDDLA62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL63:
+          componentId: AA+BBCCC=DDDDLA63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL64:
+          componentId: AA+BBCCC=DDDDLA64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL65:
+          componentId: AA+BBCCC=DDDDLA65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL66:
+          componentId: AA+BBCCC=DDDDLA66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL67:
+          componentId: AA+BBCCC=DDDDLA67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL68:
+          componentId: AA+BBCCC=DDDDLA68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL69:
+          componentId: AA+BBCCC=DDDDLA69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL70:
+          componentId: AA+BBCCC=DDDDLA70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL71:
+          componentId: AA+BBCCC=DDDDLA71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL72:
+          componentId: AA+BBCCC=DDDDLA72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL73:
+          componentId: AA+BBCCC=DDDDLA73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL74:
+          componentId: AA+BBCCC=DDDDLA74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL75:
+          componentId: AA+BBCCC=DDDDLA75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL76:
+          componentId: AA+BBCCC=DDDDLA76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL77:
+          componentId: AA+BBCCC=DDDDLA77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL78:
+          componentId: AA+BBCCC=DDDDLA78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL79:
+          componentId: AA+BBCCC=DDDDLA79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL80:
+          componentId: AA+BBCCC=DDDDLA80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL81:
+          componentId: AA+BBCCC=DDDDLA81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL82:
+          componentId: AA+BBCCC=DDDDLA82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL83:
+          componentId: AA+BBCCC=DDDDLA83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL84:
+          componentId: AA+BBCCC=DDDDLA84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL85:
+          componentId: AA+BBCCC=DDDDLA85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL86:
+          componentId: AA+BBCCC=DDDDLA86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL87:
+          componentId: AA+BBCCC=DDDDLA87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL88:
+          componentId: AA+BBCCC=DDDDLA88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL89:
+          componentId: AA+BBCCC=DDDDLA89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL90:
+          componentId: AA+BBCCC=DDDDLA90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL91:
+          componentId: AA+BBCCC=DDDDLA91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL92:
+          componentId: AA+BBCCC=DDDDLA92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL93:
+          componentId: AA+BBCCC=DDDDLA93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL94:
+          componentId: AA+BBCCC=DDDDLA94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL95:
+          componentId: AA+BBCCC=DDDDLA95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL96:
+          componentId: AA+BBCCC=DDDDLA96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL97:
+          componentId: AA+BBCCC=DDDDLA97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL98:
+          componentId: AA+BBCCC=DDDDLA98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL99:
+          componentId: AA+BBCCC=DDDDLA99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL100:
+          componentId: AA+BBCCC=DDDDL100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL101:
+          componentId: AA+BBCCC=DDDDL101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL102:
+          componentId: AA+BBCCC=DDDDL102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL103:
+          componentId: AA+BBCCC=DDDDL103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL104:
+          componentId: AA+BBCCC=DDDDL104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL105:
+          componentId: AA+BBCCC=DDDDL105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL106:
+          componentId: AA+BBCCC=DDDDL106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL107:
+          componentId: AA+BBCCC=DDDDL107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL108:
+          componentId: AA+BBCCC=DDDDL108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL109:
+          componentId: AA+BBCCC=DDDDL109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL110:
+          componentId: AA+BBCCC=DDDDL110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL111:
+          componentId: AA+BBCCC=DDDDL111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL112:
+          componentId: AA+BBCCC=DDDDL112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL113:
+          componentId: AA+BBCCC=DDDDL113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL114:
+          componentId: AA+BBCCC=DDDDL114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL115:
+          componentId: AA+BBCCC=DDDDL115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL116:
+          componentId: AA+BBCCC=DDDDL116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL117:
+          componentId: AA+BBCCC=DDDDL117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL118:
+          componentId: AA+BBCCC=DDDDL118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL119:
+          componentId: AA+BBCCC=DDDDL119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL120:
+          componentId: AA+BBCCC=DDDDL120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL121:
+          componentId: AA+BBCCC=DDDDL121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL122:
+          componentId: AA+BBCCC=DDDDL122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL123:
+          componentId: AA+BBCCC=DDDDL123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL124:
+          componentId: AA+BBCCC=DDDDL124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL125:
+          componentId: AA+BBCCC=DDDDL125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL126:
+          componentId: AA+BBCCC=DDDDL126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL127:
+          componentId: AA+BBCCC=DDDDL127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL128:
+          componentId: AA+BBCCC=DDDDL128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL129:
+          componentId: AA+BBCCC=DDDDL129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL130:
+          componentId: AA+BBCCC=DDDDL130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL131:
+          componentId: AA+BBCCC=DDDDL131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL132:
+          componentId: AA+BBCCC=DDDDL132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL133:
+          componentId: AA+BBCCC=DDDDL133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL134:
+          componentId: AA+BBCCC=DDDDL134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL135:
+          componentId: AA+BBCCC=DDDDL135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL136:
+          componentId: AA+BBCCC=DDDDL136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL137:
+          componentId: AA+BBCCC=DDDDL137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL138:
+          componentId: AA+BBCCC=DDDDL138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL139:
+          componentId: AA+BBCCC=DDDDL139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL140:
+          componentId: AA+BBCCC=DDDDL140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL141:
+          componentId: AA+BBCCC=DDDDL141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL142:
+          componentId: AA+BBCCC=DDDDL142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL143:
+          componentId: AA+BBCCC=DDDDL143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL144:
+          componentId: AA+BBCCC=DDDDL144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL145:
+          componentId: AA+BBCCC=DDDDL145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL146:
+          componentId: AA+BBCCC=DDDDL146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL147:
+          componentId: AA+BBCCC=DDDDL147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL148:
+          componentId: AA+BBCCC=DDDDL148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL149:
+          componentId: AA+BBCCC=DDDDL149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL150:
+          componentId: AA+BBCCC=DDDDL150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL151:
+          componentId: AA+BBCCC=DDDDL151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL152:
+          componentId: AA+BBCCC=DDDDL152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL153:
+          componentId: AA+BBCCC=DDDDL153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL154:
+          componentId: AA+BBCCC=DDDDL154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL155:
+          componentId: AA+BBCCC=DDDDL155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL156:
+          componentId: AA+BBCCC=DDDDL156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL157:
+          componentId: AA+BBCCC=DDDDL157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL158:
+          componentId: AA+BBCCC=DDDDL158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL159:
+          componentId: AA+BBCCC=DDDDL159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL160:
+          componentId: AA+BBCCC=DDDDL160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL161:
+          componentId: AA+BBCCC=DDDDL161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL162:
+          componentId: AA+BBCCC=DDDDL162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL163:
+          componentId: AA+BBCCC=DDDDL163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL164:
+          componentId: AA+BBCCC=DDDDL164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL165:
+          componentId: AA+BBCCC=DDDDL165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL166:
+          componentId: AA+BBCCC=DDDDL166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL167:
+          componentId: AA+BBCCC=DDDDL167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL168:
+          componentId: AA+BBCCC=DDDDL168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL169:
+          componentId: AA+BBCCC=DDDDL169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL170:
+          componentId: AA+BBCCC=DDDDL170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL171:
+          componentId: AA+BBCCC=DDDDL171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL172:
+          componentId: AA+BBCCC=DDDDL172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL173:
+          componentId: AA+BBCCC=DDDDL173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL174:
+          componentId: AA+BBCCC=DDDDL174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL175:
+          componentId: AA+BBCCC=DDDDL175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL176:
+          componentId: AA+BBCCC=DDDDL176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL177:
+          componentId: AA+BBCCC=DDDDL177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL178:
+          componentId: AA+BBCCC=DDDDL178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL179:
+          componentId: AA+BBCCC=DDDDL179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL180:
+          componentId: AA+BBCCC=DDDDL180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL181:
+          componentId: AA+BBCCC=DDDDL181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL182:
+          componentId: AA+BBCCC=DDDDL182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL183:
+          componentId: AA+BBCCC=DDDDL183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL184:
+          componentId: AA+BBCCC=DDDDL184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL185:
+          componentId: AA+BBCCC=DDDDL185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL186:
+          componentId: AA+BBCCC=DDDDL186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL187:
+          componentId: AA+BBCCC=DDDDL187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL188:
+          componentId: AA+BBCCC=DDDDL188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL189:
+          componentId: AA+BBCCC=DDDDL189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL190:
+          componentId: AA+BBCCC=DDDDL190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL191:
+          componentId: AA+BBCCC=DDDDL191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL192:
+          componentId: AA+BBCCC=DDDDL192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL193:
+          componentId: AA+BBCCC=DDDDL193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL194:
+          componentId: AA+BBCCC=DDDDL194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL195:
+          componentId: AA+BBCCC=DDDDL195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL196:
+          componentId: AA+BBCCC=DDDDL196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL197:
+          componentId: AA+BBCCC=DDDDL197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL198:
+          componentId: AA+BBCCC=DDDDL198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL199:
+          componentId: AA+BBCCC=DDDDL199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL200:
+          componentId: AA+BBCCC=DDDDL200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL201:
+          componentId: AA+BBCCC=DDDDL201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL202:
+          componentId: AA+BBCCC=DDDDL202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL203:
+          componentId: AA+BBCCC=DDDDL203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL204:
+          componentId: AA+BBCCC=DDDDL204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL205:
+          componentId: AA+BBCCC=DDDDL205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL206:
+          componentId: AA+BBCCC=DDDDL206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL207:
+          componentId: AA+BBCCC=DDDDL207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL208:
+          componentId: AA+BBCCC=DDDDL208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL209:
+          componentId: AA+BBCCC=DDDDL209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL210:
+          componentId: AA+BBCCC=DDDDL210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL211:
+          componentId: AA+BBCCC=DDDDL211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL212:
+          componentId: AA+BBCCC=DDDDL212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL213:
+          componentId: AA+BBCCC=DDDDL213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL214:
+          componentId: AA+BBCCC=DDDDL214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL215:
+          componentId: AA+BBCCC=DDDDL215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL216:
+          componentId: AA+BBCCC=DDDDL216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL217:
+          componentId: AA+BBCCC=DDDDL217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL218:
+          componentId: AA+BBCCC=DDDDL218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL219:
+          componentId: AA+BBCCC=DDDDL219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL220:
+          componentId: AA+BBCCC=DDDDL220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL221:
+          componentId: AA+BBCCC=DDDDL221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL222:
+          componentId: AA+BBCCC=DDDDL222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL223:
+          componentId: AA+BBCCC=DDDDL223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL224:
+          componentId: AA+BBCCC=DDDDL224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL225:
+          componentId: AA+BBCCC=DDDDL225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL226:
+          componentId: AA+BBCCC=DDDDL226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL227:
+          componentId: AA+BBCCC=DDDDL227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL228:
+          componentId: AA+BBCCC=DDDDL228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL229:
+          componentId: AA+BBCCC=DDDDL229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL230:
+          componentId: AA+BBCCC=DDDDL230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL231:
+          componentId: AA+BBCCC=DDDDL231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL232:
+          componentId: AA+BBCCC=DDDDL232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL233:
+          componentId: AA+BBCCC=DDDDL233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL234:
+          componentId: AA+BBCCC=DDDDL234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL235:
+          componentId: AA+BBCCC=DDDDL235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL236:
+          componentId: AA+BBCCC=DDDDL236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL237:
+          componentId: AA+BBCCC=DDDDL237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL238:
+          componentId: AA+BBCCC=DDDDL238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL239:
+          componentId: AA+BBCCC=DDDDL239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL240:
+          componentId: AA+BBCCC=DDDDL240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL241:
+          componentId: AA+BBCCC=DDDDL241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL242:
+          componentId: AA+BBCCC=DDDDL242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL243:
+          componentId: AA+BBCCC=DDDDL243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL244:
+          componentId: AA+BBCCC=DDDDL244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL245:
+          componentId: AA+BBCCC=DDDDL245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL246:
+          componentId: AA+BBCCC=DDDDL246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL247:
+          componentId: AA+BBCCC=DDDDL247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL248:
+          componentId: AA+BBCCC=DDDDL248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL249:
+          componentId: AA+BBCCC=DDDDL249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL250:
+          componentId: AA+BBCCC=DDDDL250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL251:
+          componentId: AA+BBCCC=DDDDL251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL252:
+          componentId: AA+BBCCC=DDDDL252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL253:
+          componentId: AA+BBCCC=DDDDL253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL254:
+          componentId: AA+BBCCC=DDDDL254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL255:
+          componentId: AA+BBCCC=DDDDL255
+          ntsObjectId: AA+BBCCC=DDDEEFFF

--- a/YAML/SXL_Traffic_Controller_ver_1_1-site.yaml
+++ b/YAML/SXL_Traffic_Controller_ver_1_1-site.yaml
@@ -1,0 +1,1549 @@
+---
+id: Plant id
+version: '1.1'
+date: '2022-06-23'
+description: Plant name
+constructor: RSMP Nordic
+created-date: '2010-04-20'
+rsmp-version: '3.2'
+objects:
+sites:
+  AA+BBCC:
+    description: Anl. ??
+    objects:
+      Traffic Light Controller:
+        Traffic Light Controller:
+          componentId: AA+BBCCC=DDDEEFFF
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Signal group:
+        SG1:
+          componentId: AA+BBCCC=DDDEEFF1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG2:
+          componentId: AA+BBCCC=DDDEEFF2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG3:
+          componentId: AA+BBCCC=DDDEEFF3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG4:
+          componentId: AA+BBCCC=DDDEEFF4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG5:
+          componentId: AA+BBCCC=DDDEEFF5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG6:
+          componentId: AA+BBCCC=DDDEEFF6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG7:
+          componentId: AA+BBCCC=DDDEEFF7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG8:
+          componentId: AA+BBCCC=DDDEEFF8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG9:
+          componentId: AA+BBCCC=DDDEEFF9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG10:
+          componentId: AA+BBCCC=DDDEEF10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG11:
+          componentId: AA+BBCCC=DDDEEF11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG12:
+          componentId: AA+BBCCC=DDDEEF12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG13:
+          componentId: AA+BBCCC=DDDEEF13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG14:
+          componentId: AA+BBCCC=DDDEEF14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG15:
+          componentId: AA+BBCCC=DDDEEF15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG16:
+          componentId: AA+BBCCC=DDDEEF16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG17:
+          componentId: AA+BBCCC=DDDEEF17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG18:
+          componentId: AA+BBCCC=DDDEEF18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG19:
+          componentId: AA+BBCCC=DDDEEF19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG20:
+          componentId: AA+BBCCC=DDDEEF20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG21:
+          componentId: AA+BBCCC=DDDEEF21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG22:
+          componentId: AA+BBCCC=DDDEEF22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG23:
+          componentId: AA+BBCCC=DDDEEF23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG24:
+          componentId: AA+BBCCC=DDDEEF24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG25:
+          componentId: AA+BBCCC=DDDEEF25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG26:
+          componentId: AA+BBCCC=DDDEEF26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG27:
+          componentId: AA+BBCCC=DDDEEF27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG28:
+          componentId: AA+BBCCC=DDDEEF28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG29:
+          componentId: AA+BBCCC=DDDEEF29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG30:
+          componentId: AA+BBCCC=DDDEEF30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG31:
+          componentId: AA+BBCCC=DDDEEF31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG32:
+          componentId: AA+BBCCC=DDDEEF32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG33:
+          componentId: AA+BBCCC=DDDEEF33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG34:
+          componentId: AA+BBCCC=DDDEEF34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG35:
+          componentId: AA+BBCCC=DDDEEF35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG36:
+          componentId: AA+BBCCC=DDDEEF36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG37:
+          componentId: AA+BBCCC=DDDEEF37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG38:
+          componentId: AA+BBCCC=DDDEEF38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG39:
+          componentId: AA+BBCCC=DDDEEF39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG40:
+          componentId: AA+BBCCC=DDDEEF40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG41:
+          componentId: AA+BBCCC=DDDEEF41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG42:
+          componentId: AA+BBCCC=DDDEEF42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG43:
+          componentId: AA+BBCCC=DDDEEF43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG44:
+          componentId: AA+BBCCC=DDDEEF44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG45:
+          componentId: AA+BBCCC=DDDEEF45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG46:
+          componentId: AA+BBCCC=DDDEEF46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG47:
+          componentId: AA+BBCCC=DDDEEF47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG48:
+          componentId: AA+BBCCC=DDDEEF48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG49:
+          componentId: AA+BBCCC=DDDEEF49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG50:
+          componentId: AA+BBCCC=DDDEEF50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG51:
+          componentId: AA+BBCCC=DDDEEF51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG52:
+          componentId: AA+BBCCC=DDDEEF52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG53:
+          componentId: AA+BBCCC=DDDEEF53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG54:
+          componentId: AA+BBCCC=DDDEEF54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG55:
+          componentId: AA+BBCCC=DDDEEF55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG56:
+          componentId: AA+BBCCC=DDDEEF56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG57:
+          componentId: AA+BBCCC=DDDEEF57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG58:
+          componentId: AA+BBCCC=DDDEEF58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG59:
+          componentId: AA+BBCCC=DDDEEF59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG60:
+          componentId: AA+BBCCC=DDDEEF60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG61:
+          componentId: AA+BBCCC=DDDEEF61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG62:
+          componentId: AA+BBCCC=DDDEEF62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG63:
+          componentId: AA+BBCCC=DDDEEF63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG64:
+          componentId: AA+BBCCC=DDDEEF64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG65:
+          componentId: AA+BBCCC=DDDEEF65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG66:
+          componentId: AA+BBCCC=DDDEEF66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG67:
+          componentId: AA+BBCCC=DDDEEF67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG68:
+          componentId: AA+BBCCC=DDDEEF68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG69:
+          componentId: AA+BBCCC=DDDEEF69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG70:
+          componentId: AA+BBCCC=DDDEEF70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG71:
+          componentId: AA+BBCCC=DDDEEF71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG72:
+          componentId: AA+BBCCC=DDDEEF72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG73:
+          componentId: AA+BBCCC=DDDEEF73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG74:
+          componentId: AA+BBCCC=DDDEEF74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG75:
+          componentId: AA+BBCCC=DDDEEF75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG76:
+          componentId: AA+BBCCC=DDDEEF76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG77:
+          componentId: AA+BBCCC=DDDEEF77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG78:
+          componentId: AA+BBCCC=DDDEEF78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG79:
+          componentId: AA+BBCCC=DDDEEF79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG80:
+          componentId: AA+BBCCC=DDDEEF80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG81:
+          componentId: AA+BBCCC=DDDEEF81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG82:
+          componentId: AA+BBCCC=DDDEEF82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG83:
+          componentId: AA+BBCCC=DDDEEF83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG84:
+          componentId: AA+BBCCC=DDDEEF84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG85:
+          componentId: AA+BBCCC=DDDEEF85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG86:
+          componentId: AA+BBCCC=DDDEEF86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG87:
+          componentId: AA+BBCCC=DDDEEF87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG88:
+          componentId: AA+BBCCC=DDDEEF88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG89:
+          componentId: AA+BBCCC=DDDEEF89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG90:
+          componentId: AA+BBCCC=DDDEEF90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG91:
+          componentId: AA+BBCCC=DDDEEF91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG92:
+          componentId: AA+BBCCC=DDDEEF92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG93:
+          componentId: AA+BBCCC=DDDEEF93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG94:
+          componentId: AA+BBCCC=DDDEEF94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG95:
+          componentId: AA+BBCCC=DDDEEF95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG96:
+          componentId: AA+BBCCC=DDDEEF96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG97:
+          componentId: AA+BBCCC=DDDEEF97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG98:
+          componentId: AA+BBCCC=DDDEEF98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG99:
+          componentId: AA+BBCCC=DDDEEF99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG100:
+          componentId: AA+BBCCC=DDDEE100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG101:
+          componentId: AA+BBCCC=DDDEE101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG102:
+          componentId: AA+BBCCC=DDDEE102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG103:
+          componentId: AA+BBCCC=DDDEE103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG104:
+          componentId: AA+BBCCC=DDDEE104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG105:
+          componentId: AA+BBCCC=DDDEE105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG106:
+          componentId: AA+BBCCC=DDDEE106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG107:
+          componentId: AA+BBCCC=DDDEE107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG108:
+          componentId: AA+BBCCC=DDDEE108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG109:
+          componentId: AA+BBCCC=DDDEE109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG110:
+          componentId: AA+BBCCC=DDDEE110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG111:
+          componentId: AA+BBCCC=DDDEE111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG112:
+          componentId: AA+BBCCC=DDDEE112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG113:
+          componentId: AA+BBCCC=DDDEE113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG114:
+          componentId: AA+BBCCC=DDDEE114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG115:
+          componentId: AA+BBCCC=DDDEE115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG116:
+          componentId: AA+BBCCC=DDDEE116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG117:
+          componentId: AA+BBCCC=DDDEE117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG118:
+          componentId: AA+BBCCC=DDDEE118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG119:
+          componentId: AA+BBCCC=DDDEE119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG120:
+          componentId: AA+BBCCC=DDDEE120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG121:
+          componentId: AA+BBCCC=DDDEE121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG122:
+          componentId: AA+BBCCC=DDDEE122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG123:
+          componentId: AA+BBCCC=DDDEE123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG124:
+          componentId: AA+BBCCC=DDDEE124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG125:
+          componentId: AA+BBCCC=DDDEE125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG126:
+          componentId: AA+BBCCC=DDDEE126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG127:
+          componentId: AA+BBCCC=DDDEE127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG128:
+          componentId: AA+BBCCC=DDDEE128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG129:
+          componentId: AA+BBCCC=DDDEE129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG130:
+          componentId: AA+BBCCC=DDDEE130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG131:
+          componentId: AA+BBCCC=DDDEE131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG132:
+          componentId: AA+BBCCC=DDDEE132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG133:
+          componentId: AA+BBCCC=DDDEE133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG134:
+          componentId: AA+BBCCC=DDDEE134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG135:
+          componentId: AA+BBCCC=DDDEE135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG136:
+          componentId: AA+BBCCC=DDDEE136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG137:
+          componentId: AA+BBCCC=DDDEE137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG138:
+          componentId: AA+BBCCC=DDDEE138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG139:
+          componentId: AA+BBCCC=DDDEE139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG140:
+          componentId: AA+BBCCC=DDDEE140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG141:
+          componentId: AA+BBCCC=DDDEE141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG142:
+          componentId: AA+BBCCC=DDDEE142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG143:
+          componentId: AA+BBCCC=DDDEE143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG144:
+          componentId: AA+BBCCC=DDDEE144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG145:
+          componentId: AA+BBCCC=DDDEE145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG146:
+          componentId: AA+BBCCC=DDDEE146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG147:
+          componentId: AA+BBCCC=DDDEE147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG148:
+          componentId: AA+BBCCC=DDDEE148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG149:
+          componentId: AA+BBCCC=DDDEE149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG150:
+          componentId: AA+BBCCC=DDDEE150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG151:
+          componentId: AA+BBCCC=DDDEE151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG152:
+          componentId: AA+BBCCC=DDDEE152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG153:
+          componentId: AA+BBCCC=DDDEE153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG154:
+          componentId: AA+BBCCC=DDDEE154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG155:
+          componentId: AA+BBCCC=DDDEE155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG156:
+          componentId: AA+BBCCC=DDDEE156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG157:
+          componentId: AA+BBCCC=DDDEE157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG158:
+          componentId: AA+BBCCC=DDDEE158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG159:
+          componentId: AA+BBCCC=DDDEE159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG160:
+          componentId: AA+BBCCC=DDDEE160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG161:
+          componentId: AA+BBCCC=DDDEE161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG162:
+          componentId: AA+BBCCC=DDDEE162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG163:
+          componentId: AA+BBCCC=DDDEE163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG164:
+          componentId: AA+BBCCC=DDDEE164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG165:
+          componentId: AA+BBCCC=DDDEE165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG166:
+          componentId: AA+BBCCC=DDDEE166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG167:
+          componentId: AA+BBCCC=DDDEE167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG168:
+          componentId: AA+BBCCC=DDDEE168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG169:
+          componentId: AA+BBCCC=DDDEE169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG170:
+          componentId: AA+BBCCC=DDDEE170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG171:
+          componentId: AA+BBCCC=DDDEE171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG172:
+          componentId: AA+BBCCC=DDDEE172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG173:
+          componentId: AA+BBCCC=DDDEE173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG174:
+          componentId: AA+BBCCC=DDDEE174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG175:
+          componentId: AA+BBCCC=DDDEE175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG176:
+          componentId: AA+BBCCC=DDDEE176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG177:
+          componentId: AA+BBCCC=DDDEE177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG178:
+          componentId: AA+BBCCC=DDDEE178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG179:
+          componentId: AA+BBCCC=DDDEE179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG180:
+          componentId: AA+BBCCC=DDDEE180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG181:
+          componentId: AA+BBCCC=DDDEE181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG182:
+          componentId: AA+BBCCC=DDDEE182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG183:
+          componentId: AA+BBCCC=DDDEE183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG184:
+          componentId: AA+BBCCC=DDDEE184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG185:
+          componentId: AA+BBCCC=DDDEE185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG186:
+          componentId: AA+BBCCC=DDDEE186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG187:
+          componentId: AA+BBCCC=DDDEE187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG188:
+          componentId: AA+BBCCC=DDDEE188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG189:
+          componentId: AA+BBCCC=DDDEE189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG190:
+          componentId: AA+BBCCC=DDDEE190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG191:
+          componentId: AA+BBCCC=DDDEE191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG192:
+          componentId: AA+BBCCC=DDDEE192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG193:
+          componentId: AA+BBCCC=DDDEE193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG194:
+          componentId: AA+BBCCC=DDDEE194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG195:
+          componentId: AA+BBCCC=DDDEE195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG196:
+          componentId: AA+BBCCC=DDDEE196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG197:
+          componentId: AA+BBCCC=DDDEE197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG198:
+          componentId: AA+BBCCC=DDDEE198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG199:
+          componentId: AA+BBCCC=DDDEE199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG200:
+          componentId: AA+BBCCC=DDDEE200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG201:
+          componentId: AA+BBCCC=DDDEE201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG202:
+          componentId: AA+BBCCC=DDDEE202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG203:
+          componentId: AA+BBCCC=DDDEE203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG204:
+          componentId: AA+BBCCC=DDDEE204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG205:
+          componentId: AA+BBCCC=DDDEE205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG206:
+          componentId: AA+BBCCC=DDDEE206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG207:
+          componentId: AA+BBCCC=DDDEE207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG208:
+          componentId: AA+BBCCC=DDDEE208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG209:
+          componentId: AA+BBCCC=DDDEE209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG210:
+          componentId: AA+BBCCC=DDDEE210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG211:
+          componentId: AA+BBCCC=DDDEE211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG212:
+          componentId: AA+BBCCC=DDDEE212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG213:
+          componentId: AA+BBCCC=DDDEE213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG214:
+          componentId: AA+BBCCC=DDDEE214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG215:
+          componentId: AA+BBCCC=DDDEE215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG216:
+          componentId: AA+BBCCC=DDDEE216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG217:
+          componentId: AA+BBCCC=DDDEE217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG218:
+          componentId: AA+BBCCC=DDDEE218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG219:
+          componentId: AA+BBCCC=DDDEE219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG220:
+          componentId: AA+BBCCC=DDDEE220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG221:
+          componentId: AA+BBCCC=DDDEE221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG222:
+          componentId: AA+BBCCC=DDDEE222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG223:
+          componentId: AA+BBCCC=DDDEE223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG224:
+          componentId: AA+BBCCC=DDDEE224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG225:
+          componentId: AA+BBCCC=DDDEE225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG226:
+          componentId: AA+BBCCC=DDDEE226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG227:
+          componentId: AA+BBCCC=DDDEE227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG228:
+          componentId: AA+BBCCC=DDDEE228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG229:
+          componentId: AA+BBCCC=DDDEE229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG230:
+          componentId: AA+BBCCC=DDDEE230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG231:
+          componentId: AA+BBCCC=DDDEE231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG232:
+          componentId: AA+BBCCC=DDDEE232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG233:
+          componentId: AA+BBCCC=DDDEE233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG234:
+          componentId: AA+BBCCC=DDDEE234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG235:
+          componentId: AA+BBCCC=DDDEE235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG236:
+          componentId: AA+BBCCC=DDDEE236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG237:
+          componentId: AA+BBCCC=DDDEE237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG238:
+          componentId: AA+BBCCC=DDDEE238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG239:
+          componentId: AA+BBCCC=DDDEE239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG240:
+          componentId: AA+BBCCC=DDDEE240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG241:
+          componentId: AA+BBCCC=DDDEE241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG242:
+          componentId: AA+BBCCC=DDDEE242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG243:
+          componentId: AA+BBCCC=DDDEE243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG244:
+          componentId: AA+BBCCC=DDDEE244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG245:
+          componentId: AA+BBCCC=DDDEE245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG246:
+          componentId: AA+BBCCC=DDDEE246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG247:
+          componentId: AA+BBCCC=DDDEE247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG248:
+          componentId: AA+BBCCC=DDDEE248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG249:
+          componentId: AA+BBCCC=DDDEE249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG250:
+          componentId: AA+BBCCC=DDDEE250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG251:
+          componentId: AA+BBCCC=DDDEE251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG252:
+          componentId: AA+BBCCC=DDDEE252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG253:
+          componentId: AA+BBCCC=DDDEE253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG254:
+          componentId: AA+BBCCC=DDDEE254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG255:
+          componentId: AA+BBCCC=DDDEE255
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Detector logic:
+        DL1:
+          componentId: AA+BBCCC=DDDDLAA1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL2:
+          componentId: AA+BBCCC=DDDDLAA2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL3:
+          componentId: AA+BBCCC=DDDDLAA3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL4:
+          componentId: AA+BBCCC=DDDDLAA4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL5:
+          componentId: AA+BBCCC=DDDDLAA5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL6:
+          componentId: AA+BBCCC=DDDDLAA6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL7:
+          componentId: AA+BBCCC=DDDDLAA7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL8:
+          componentId: AA+BBCCC=DDDDLAA8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL9:
+          componentId: AA+BBCCC=DDDDLAA9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL10:
+          componentId: AA+BBCCC=DDDDLA10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL11:
+          componentId: AA+BBCCC=DDDDLA11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL12:
+          componentId: AA+BBCCC=DDDDLA12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL13:
+          componentId: AA+BBCCC=DDDDLA13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL14:
+          componentId: AA+BBCCC=DDDDLA14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL15:
+          componentId: AA+BBCCC=DDDDLA15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL16:
+          componentId: AA+BBCCC=DDDDLA16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL17:
+          componentId: AA+BBCCC=DDDDLA17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL18:
+          componentId: AA+BBCCC=DDDDLA18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL19:
+          componentId: AA+BBCCC=DDDDLA19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL20:
+          componentId: AA+BBCCC=DDDDLA20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL21:
+          componentId: AA+BBCCC=DDDDLA21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL22:
+          componentId: AA+BBCCC=DDDDLA22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL23:
+          componentId: AA+BBCCC=DDDDLA23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL24:
+          componentId: AA+BBCCC=DDDDLA24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL25:
+          componentId: AA+BBCCC=DDDDLA25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL26:
+          componentId: AA+BBCCC=DDDDLA26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL27:
+          componentId: AA+BBCCC=DDDDLA27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL28:
+          componentId: AA+BBCCC=DDDDLA28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL29:
+          componentId: AA+BBCCC=DDDDLA29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL30:
+          componentId: AA+BBCCC=DDDDLA30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL31:
+          componentId: AA+BBCCC=DDDDLA31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL32:
+          componentId: AA+BBCCC=DDDDLA32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL33:
+          componentId: AA+BBCCC=DDDDLA33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL34:
+          componentId: AA+BBCCC=DDDDLA34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL35:
+          componentId: AA+BBCCC=DDDDLA35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL36:
+          componentId: AA+BBCCC=DDDDLA36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL37:
+          componentId: AA+BBCCC=DDDDLA37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL38:
+          componentId: AA+BBCCC=DDDDLA38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL39:
+          componentId: AA+BBCCC=DDDDLA39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL40:
+          componentId: AA+BBCCC=DDDDLA40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL41:
+          componentId: AA+BBCCC=DDDDLA41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL42:
+          componentId: AA+BBCCC=DDDDLA42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL43:
+          componentId: AA+BBCCC=DDDDLA43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL44:
+          componentId: AA+BBCCC=DDDDLA44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL45:
+          componentId: AA+BBCCC=DDDDLA45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL46:
+          componentId: AA+BBCCC=DDDDLA46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL47:
+          componentId: AA+BBCCC=DDDDLA47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL48:
+          componentId: AA+BBCCC=DDDDLA48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL49:
+          componentId: AA+BBCCC=DDDDLA49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL50:
+          componentId: AA+BBCCC=DDDDLA50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL51:
+          componentId: AA+BBCCC=DDDDLA51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL52:
+          componentId: AA+BBCCC=DDDDLA52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL53:
+          componentId: AA+BBCCC=DDDDLA53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL54:
+          componentId: AA+BBCCC=DDDDLA54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL55:
+          componentId: AA+BBCCC=DDDDLA55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL56:
+          componentId: AA+BBCCC=DDDDLA56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL57:
+          componentId: AA+BBCCC=DDDDLA57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL58:
+          componentId: AA+BBCCC=DDDDLA58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL59:
+          componentId: AA+BBCCC=DDDDLA59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL60:
+          componentId: AA+BBCCC=DDDDLA60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL61:
+          componentId: AA+BBCCC=DDDDLA61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL62:
+          componentId: AA+BBCCC=DDDDLA62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL63:
+          componentId: AA+BBCCC=DDDDLA63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL64:
+          componentId: AA+BBCCC=DDDDLA64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL65:
+          componentId: AA+BBCCC=DDDDLA65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL66:
+          componentId: AA+BBCCC=DDDDLA66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL67:
+          componentId: AA+BBCCC=DDDDLA67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL68:
+          componentId: AA+BBCCC=DDDDLA68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL69:
+          componentId: AA+BBCCC=DDDDLA69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL70:
+          componentId: AA+BBCCC=DDDDLA70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL71:
+          componentId: AA+BBCCC=DDDDLA71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL72:
+          componentId: AA+BBCCC=DDDDLA72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL73:
+          componentId: AA+BBCCC=DDDDLA73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL74:
+          componentId: AA+BBCCC=DDDDLA74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL75:
+          componentId: AA+BBCCC=DDDDLA75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL76:
+          componentId: AA+BBCCC=DDDDLA76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL77:
+          componentId: AA+BBCCC=DDDDLA77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL78:
+          componentId: AA+BBCCC=DDDDLA78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL79:
+          componentId: AA+BBCCC=DDDDLA79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL80:
+          componentId: AA+BBCCC=DDDDLA80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL81:
+          componentId: AA+BBCCC=DDDDLA81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL82:
+          componentId: AA+BBCCC=DDDDLA82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL83:
+          componentId: AA+BBCCC=DDDDLA83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL84:
+          componentId: AA+BBCCC=DDDDLA84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL85:
+          componentId: AA+BBCCC=DDDDLA85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL86:
+          componentId: AA+BBCCC=DDDDLA86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL87:
+          componentId: AA+BBCCC=DDDDLA87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL88:
+          componentId: AA+BBCCC=DDDDLA88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL89:
+          componentId: AA+BBCCC=DDDDLA89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL90:
+          componentId: AA+BBCCC=DDDDLA90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL91:
+          componentId: AA+BBCCC=DDDDLA91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL92:
+          componentId: AA+BBCCC=DDDDLA92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL93:
+          componentId: AA+BBCCC=DDDDLA93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL94:
+          componentId: AA+BBCCC=DDDDLA94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL95:
+          componentId: AA+BBCCC=DDDDLA95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL96:
+          componentId: AA+BBCCC=DDDDLA96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL97:
+          componentId: AA+BBCCC=DDDDLA97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL98:
+          componentId: AA+BBCCC=DDDDLA98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL99:
+          componentId: AA+BBCCC=DDDDLA99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL100:
+          componentId: AA+BBCCC=DDDDL100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL101:
+          componentId: AA+BBCCC=DDDDL101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL102:
+          componentId: AA+BBCCC=DDDDL102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL103:
+          componentId: AA+BBCCC=DDDDL103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL104:
+          componentId: AA+BBCCC=DDDDL104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL105:
+          componentId: AA+BBCCC=DDDDL105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL106:
+          componentId: AA+BBCCC=DDDDL106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL107:
+          componentId: AA+BBCCC=DDDDL107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL108:
+          componentId: AA+BBCCC=DDDDL108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL109:
+          componentId: AA+BBCCC=DDDDL109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL110:
+          componentId: AA+BBCCC=DDDDL110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL111:
+          componentId: AA+BBCCC=DDDDL111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL112:
+          componentId: AA+BBCCC=DDDDL112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL113:
+          componentId: AA+BBCCC=DDDDL113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL114:
+          componentId: AA+BBCCC=DDDDL114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL115:
+          componentId: AA+BBCCC=DDDDL115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL116:
+          componentId: AA+BBCCC=DDDDL116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL117:
+          componentId: AA+BBCCC=DDDDL117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL118:
+          componentId: AA+BBCCC=DDDDL118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL119:
+          componentId: AA+BBCCC=DDDDL119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL120:
+          componentId: AA+BBCCC=DDDDL120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL121:
+          componentId: AA+BBCCC=DDDDL121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL122:
+          componentId: AA+BBCCC=DDDDL122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL123:
+          componentId: AA+BBCCC=DDDDL123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL124:
+          componentId: AA+BBCCC=DDDDL124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL125:
+          componentId: AA+BBCCC=DDDDL125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL126:
+          componentId: AA+BBCCC=DDDDL126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL127:
+          componentId: AA+BBCCC=DDDDL127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL128:
+          componentId: AA+BBCCC=DDDDL128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL129:
+          componentId: AA+BBCCC=DDDDL129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL130:
+          componentId: AA+BBCCC=DDDDL130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL131:
+          componentId: AA+BBCCC=DDDDL131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL132:
+          componentId: AA+BBCCC=DDDDL132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL133:
+          componentId: AA+BBCCC=DDDDL133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL134:
+          componentId: AA+BBCCC=DDDDL134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL135:
+          componentId: AA+BBCCC=DDDDL135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL136:
+          componentId: AA+BBCCC=DDDDL136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL137:
+          componentId: AA+BBCCC=DDDDL137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL138:
+          componentId: AA+BBCCC=DDDDL138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL139:
+          componentId: AA+BBCCC=DDDDL139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL140:
+          componentId: AA+BBCCC=DDDDL140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL141:
+          componentId: AA+BBCCC=DDDDL141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL142:
+          componentId: AA+BBCCC=DDDDL142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL143:
+          componentId: AA+BBCCC=DDDDL143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL144:
+          componentId: AA+BBCCC=DDDDL144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL145:
+          componentId: AA+BBCCC=DDDDL145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL146:
+          componentId: AA+BBCCC=DDDDL146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL147:
+          componentId: AA+BBCCC=DDDDL147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL148:
+          componentId: AA+BBCCC=DDDDL148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL149:
+          componentId: AA+BBCCC=DDDDL149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL150:
+          componentId: AA+BBCCC=DDDDL150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL151:
+          componentId: AA+BBCCC=DDDDL151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL152:
+          componentId: AA+BBCCC=DDDDL152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL153:
+          componentId: AA+BBCCC=DDDDL153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL154:
+          componentId: AA+BBCCC=DDDDL154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL155:
+          componentId: AA+BBCCC=DDDDL155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL156:
+          componentId: AA+BBCCC=DDDDL156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL157:
+          componentId: AA+BBCCC=DDDDL157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL158:
+          componentId: AA+BBCCC=DDDDL158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL159:
+          componentId: AA+BBCCC=DDDDL159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL160:
+          componentId: AA+BBCCC=DDDDL160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL161:
+          componentId: AA+BBCCC=DDDDL161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL162:
+          componentId: AA+BBCCC=DDDDL162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL163:
+          componentId: AA+BBCCC=DDDDL163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL164:
+          componentId: AA+BBCCC=DDDDL164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL165:
+          componentId: AA+BBCCC=DDDDL165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL166:
+          componentId: AA+BBCCC=DDDDL166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL167:
+          componentId: AA+BBCCC=DDDDL167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL168:
+          componentId: AA+BBCCC=DDDDL168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL169:
+          componentId: AA+BBCCC=DDDDL169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL170:
+          componentId: AA+BBCCC=DDDDL170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL171:
+          componentId: AA+BBCCC=DDDDL171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL172:
+          componentId: AA+BBCCC=DDDDL172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL173:
+          componentId: AA+BBCCC=DDDDL173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL174:
+          componentId: AA+BBCCC=DDDDL174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL175:
+          componentId: AA+BBCCC=DDDDL175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL176:
+          componentId: AA+BBCCC=DDDDL176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL177:
+          componentId: AA+BBCCC=DDDDL177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL178:
+          componentId: AA+BBCCC=DDDDL178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL179:
+          componentId: AA+BBCCC=DDDDL179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL180:
+          componentId: AA+BBCCC=DDDDL180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL181:
+          componentId: AA+BBCCC=DDDDL181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL182:
+          componentId: AA+BBCCC=DDDDL182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL183:
+          componentId: AA+BBCCC=DDDDL183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL184:
+          componentId: AA+BBCCC=DDDDL184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL185:
+          componentId: AA+BBCCC=DDDDL185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL186:
+          componentId: AA+BBCCC=DDDDL186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL187:
+          componentId: AA+BBCCC=DDDDL187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL188:
+          componentId: AA+BBCCC=DDDDL188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL189:
+          componentId: AA+BBCCC=DDDDL189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL190:
+          componentId: AA+BBCCC=DDDDL190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL191:
+          componentId: AA+BBCCC=DDDDL191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL192:
+          componentId: AA+BBCCC=DDDDL192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL193:
+          componentId: AA+BBCCC=DDDDL193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL194:
+          componentId: AA+BBCCC=DDDDL194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL195:
+          componentId: AA+BBCCC=DDDDL195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL196:
+          componentId: AA+BBCCC=DDDDL196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL197:
+          componentId: AA+BBCCC=DDDDL197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL198:
+          componentId: AA+BBCCC=DDDDL198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL199:
+          componentId: AA+BBCCC=DDDDL199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL200:
+          componentId: AA+BBCCC=DDDDL200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL201:
+          componentId: AA+BBCCC=DDDDL201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL202:
+          componentId: AA+BBCCC=DDDDL202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL203:
+          componentId: AA+BBCCC=DDDDL203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL204:
+          componentId: AA+BBCCC=DDDDL204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL205:
+          componentId: AA+BBCCC=DDDDL205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL206:
+          componentId: AA+BBCCC=DDDDL206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL207:
+          componentId: AA+BBCCC=DDDDL207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL208:
+          componentId: AA+BBCCC=DDDDL208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL209:
+          componentId: AA+BBCCC=DDDDL209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL210:
+          componentId: AA+BBCCC=DDDDL210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL211:
+          componentId: AA+BBCCC=DDDDL211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL212:
+          componentId: AA+BBCCC=DDDDL212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL213:
+          componentId: AA+BBCCC=DDDDL213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL214:
+          componentId: AA+BBCCC=DDDDL214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL215:
+          componentId: AA+BBCCC=DDDDL215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL216:
+          componentId: AA+BBCCC=DDDDL216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL217:
+          componentId: AA+BBCCC=DDDDL217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL218:
+          componentId: AA+BBCCC=DDDDL218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL219:
+          componentId: AA+BBCCC=DDDDL219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL220:
+          componentId: AA+BBCCC=DDDDL220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL221:
+          componentId: AA+BBCCC=DDDDL221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL222:
+          componentId: AA+BBCCC=DDDDL222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL223:
+          componentId: AA+BBCCC=DDDDL223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL224:
+          componentId: AA+BBCCC=DDDDL224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL225:
+          componentId: AA+BBCCC=DDDDL225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL226:
+          componentId: AA+BBCCC=DDDDL226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL227:
+          componentId: AA+BBCCC=DDDDL227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL228:
+          componentId: AA+BBCCC=DDDDL228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL229:
+          componentId: AA+BBCCC=DDDDL229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL230:
+          componentId: AA+BBCCC=DDDDL230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL231:
+          componentId: AA+BBCCC=DDDDL231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL232:
+          componentId: AA+BBCCC=DDDDL232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL233:
+          componentId: AA+BBCCC=DDDDL233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL234:
+          componentId: AA+BBCCC=DDDDL234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL235:
+          componentId: AA+BBCCC=DDDDL235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL236:
+          componentId: AA+BBCCC=DDDDL236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL237:
+          componentId: AA+BBCCC=DDDDL237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL238:
+          componentId: AA+BBCCC=DDDDL238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL239:
+          componentId: AA+BBCCC=DDDDL239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL240:
+          componentId: AA+BBCCC=DDDDL240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL241:
+          componentId: AA+BBCCC=DDDDL241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL242:
+          componentId: AA+BBCCC=DDDDL242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL243:
+          componentId: AA+BBCCC=DDDDL243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL244:
+          componentId: AA+BBCCC=DDDDL244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL245:
+          componentId: AA+BBCCC=DDDDL245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL246:
+          componentId: AA+BBCCC=DDDDL246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL247:
+          componentId: AA+BBCCC=DDDDL247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL248:
+          componentId: AA+BBCCC=DDDDL248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL249:
+          componentId: AA+BBCCC=DDDDL249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL250:
+          componentId: AA+BBCCC=DDDDL250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL251:
+          componentId: AA+BBCCC=DDDDL251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL252:
+          componentId: AA+BBCCC=DDDDL252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL253:
+          componentId: AA+BBCCC=DDDDL253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL254:
+          componentId: AA+BBCCC=DDDDL254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL255:
+          componentId: AA+BBCCC=DDDDL255
+          ntsObjectId: AA+BBCCC=DDDEEFFF

--- a/YAML/SXL_Traffic_Controller_ver_1_2-site.yaml
+++ b/YAML/SXL_Traffic_Controller_ver_1_2-site.yaml
@@ -1,0 +1,1549 @@
+---
+id: Plant id
+version: '1.2'
+date: '2023-10-03'
+description: Plant name
+constructor: RSMP Nordic
+created-date: '2010-04-20'
+rsmp-version: '3.2.1'
+objects:
+sites:
+  AA+BBCC:
+    description: Anl. ??
+    objects:
+      Traffic Light Controller:
+        Traffic Light Controller:
+          componentId: AA+BBCCC=DDDEEFFF
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Signal group:
+        SG1:
+          componentId: AA+BBCCC=DDDEEFF1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG2:
+          componentId: AA+BBCCC=DDDEEFF2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG3:
+          componentId: AA+BBCCC=DDDEEFF3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG4:
+          componentId: AA+BBCCC=DDDEEFF4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG5:
+          componentId: AA+BBCCC=DDDEEFF5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG6:
+          componentId: AA+BBCCC=DDDEEFF6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG7:
+          componentId: AA+BBCCC=DDDEEFF7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG8:
+          componentId: AA+BBCCC=DDDEEFF8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG9:
+          componentId: AA+BBCCC=DDDEEFF9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG10:
+          componentId: AA+BBCCC=DDDEEF10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG11:
+          componentId: AA+BBCCC=DDDEEF11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG12:
+          componentId: AA+BBCCC=DDDEEF12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG13:
+          componentId: AA+BBCCC=DDDEEF13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG14:
+          componentId: AA+BBCCC=DDDEEF14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG15:
+          componentId: AA+BBCCC=DDDEEF15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG16:
+          componentId: AA+BBCCC=DDDEEF16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG17:
+          componentId: AA+BBCCC=DDDEEF17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG18:
+          componentId: AA+BBCCC=DDDEEF18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG19:
+          componentId: AA+BBCCC=DDDEEF19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG20:
+          componentId: AA+BBCCC=DDDEEF20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG21:
+          componentId: AA+BBCCC=DDDEEF21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG22:
+          componentId: AA+BBCCC=DDDEEF22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG23:
+          componentId: AA+BBCCC=DDDEEF23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG24:
+          componentId: AA+BBCCC=DDDEEF24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG25:
+          componentId: AA+BBCCC=DDDEEF25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG26:
+          componentId: AA+BBCCC=DDDEEF26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG27:
+          componentId: AA+BBCCC=DDDEEF27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG28:
+          componentId: AA+BBCCC=DDDEEF28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG29:
+          componentId: AA+BBCCC=DDDEEF29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG30:
+          componentId: AA+BBCCC=DDDEEF30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG31:
+          componentId: AA+BBCCC=DDDEEF31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG32:
+          componentId: AA+BBCCC=DDDEEF32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG33:
+          componentId: AA+BBCCC=DDDEEF33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG34:
+          componentId: AA+BBCCC=DDDEEF34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG35:
+          componentId: AA+BBCCC=DDDEEF35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG36:
+          componentId: AA+BBCCC=DDDEEF36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG37:
+          componentId: AA+BBCCC=DDDEEF37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG38:
+          componentId: AA+BBCCC=DDDEEF38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG39:
+          componentId: AA+BBCCC=DDDEEF39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG40:
+          componentId: AA+BBCCC=DDDEEF40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG41:
+          componentId: AA+BBCCC=DDDEEF41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG42:
+          componentId: AA+BBCCC=DDDEEF42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG43:
+          componentId: AA+BBCCC=DDDEEF43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG44:
+          componentId: AA+BBCCC=DDDEEF44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG45:
+          componentId: AA+BBCCC=DDDEEF45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG46:
+          componentId: AA+BBCCC=DDDEEF46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG47:
+          componentId: AA+BBCCC=DDDEEF47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG48:
+          componentId: AA+BBCCC=DDDEEF48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG49:
+          componentId: AA+BBCCC=DDDEEF49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG50:
+          componentId: AA+BBCCC=DDDEEF50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG51:
+          componentId: AA+BBCCC=DDDEEF51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG52:
+          componentId: AA+BBCCC=DDDEEF52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG53:
+          componentId: AA+BBCCC=DDDEEF53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG54:
+          componentId: AA+BBCCC=DDDEEF54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG55:
+          componentId: AA+BBCCC=DDDEEF55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG56:
+          componentId: AA+BBCCC=DDDEEF56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG57:
+          componentId: AA+BBCCC=DDDEEF57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG58:
+          componentId: AA+BBCCC=DDDEEF58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG59:
+          componentId: AA+BBCCC=DDDEEF59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG60:
+          componentId: AA+BBCCC=DDDEEF60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG61:
+          componentId: AA+BBCCC=DDDEEF61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG62:
+          componentId: AA+BBCCC=DDDEEF62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG63:
+          componentId: AA+BBCCC=DDDEEF63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG64:
+          componentId: AA+BBCCC=DDDEEF64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG65:
+          componentId: AA+BBCCC=DDDEEF65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG66:
+          componentId: AA+BBCCC=DDDEEF66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG67:
+          componentId: AA+BBCCC=DDDEEF67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG68:
+          componentId: AA+BBCCC=DDDEEF68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG69:
+          componentId: AA+BBCCC=DDDEEF69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG70:
+          componentId: AA+BBCCC=DDDEEF70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG71:
+          componentId: AA+BBCCC=DDDEEF71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG72:
+          componentId: AA+BBCCC=DDDEEF72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG73:
+          componentId: AA+BBCCC=DDDEEF73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG74:
+          componentId: AA+BBCCC=DDDEEF74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG75:
+          componentId: AA+BBCCC=DDDEEF75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG76:
+          componentId: AA+BBCCC=DDDEEF76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG77:
+          componentId: AA+BBCCC=DDDEEF77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG78:
+          componentId: AA+BBCCC=DDDEEF78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG79:
+          componentId: AA+BBCCC=DDDEEF79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG80:
+          componentId: AA+BBCCC=DDDEEF80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG81:
+          componentId: AA+BBCCC=DDDEEF81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG82:
+          componentId: AA+BBCCC=DDDEEF82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG83:
+          componentId: AA+BBCCC=DDDEEF83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG84:
+          componentId: AA+BBCCC=DDDEEF84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG85:
+          componentId: AA+BBCCC=DDDEEF85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG86:
+          componentId: AA+BBCCC=DDDEEF86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG87:
+          componentId: AA+BBCCC=DDDEEF87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG88:
+          componentId: AA+BBCCC=DDDEEF88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG89:
+          componentId: AA+BBCCC=DDDEEF89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG90:
+          componentId: AA+BBCCC=DDDEEF90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG91:
+          componentId: AA+BBCCC=DDDEEF91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG92:
+          componentId: AA+BBCCC=DDDEEF92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG93:
+          componentId: AA+BBCCC=DDDEEF93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG94:
+          componentId: AA+BBCCC=DDDEEF94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG95:
+          componentId: AA+BBCCC=DDDEEF95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG96:
+          componentId: AA+BBCCC=DDDEEF96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG97:
+          componentId: AA+BBCCC=DDDEEF97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG98:
+          componentId: AA+BBCCC=DDDEEF98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG99:
+          componentId: AA+BBCCC=DDDEEF99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG100:
+          componentId: AA+BBCCC=DDDEE100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG101:
+          componentId: AA+BBCCC=DDDEE101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG102:
+          componentId: AA+BBCCC=DDDEE102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG103:
+          componentId: AA+BBCCC=DDDEE103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG104:
+          componentId: AA+BBCCC=DDDEE104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG105:
+          componentId: AA+BBCCC=DDDEE105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG106:
+          componentId: AA+BBCCC=DDDEE106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG107:
+          componentId: AA+BBCCC=DDDEE107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG108:
+          componentId: AA+BBCCC=DDDEE108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG109:
+          componentId: AA+BBCCC=DDDEE109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG110:
+          componentId: AA+BBCCC=DDDEE110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG111:
+          componentId: AA+BBCCC=DDDEE111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG112:
+          componentId: AA+BBCCC=DDDEE112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG113:
+          componentId: AA+BBCCC=DDDEE113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG114:
+          componentId: AA+BBCCC=DDDEE114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG115:
+          componentId: AA+BBCCC=DDDEE115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG116:
+          componentId: AA+BBCCC=DDDEE116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG117:
+          componentId: AA+BBCCC=DDDEE117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG118:
+          componentId: AA+BBCCC=DDDEE118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG119:
+          componentId: AA+BBCCC=DDDEE119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG120:
+          componentId: AA+BBCCC=DDDEE120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG121:
+          componentId: AA+BBCCC=DDDEE121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG122:
+          componentId: AA+BBCCC=DDDEE122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG123:
+          componentId: AA+BBCCC=DDDEE123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG124:
+          componentId: AA+BBCCC=DDDEE124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG125:
+          componentId: AA+BBCCC=DDDEE125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG126:
+          componentId: AA+BBCCC=DDDEE126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG127:
+          componentId: AA+BBCCC=DDDEE127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG128:
+          componentId: AA+BBCCC=DDDEE128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG129:
+          componentId: AA+BBCCC=DDDEE129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG130:
+          componentId: AA+BBCCC=DDDEE130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG131:
+          componentId: AA+BBCCC=DDDEE131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG132:
+          componentId: AA+BBCCC=DDDEE132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG133:
+          componentId: AA+BBCCC=DDDEE133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG134:
+          componentId: AA+BBCCC=DDDEE134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG135:
+          componentId: AA+BBCCC=DDDEE135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG136:
+          componentId: AA+BBCCC=DDDEE136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG137:
+          componentId: AA+BBCCC=DDDEE137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG138:
+          componentId: AA+BBCCC=DDDEE138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG139:
+          componentId: AA+BBCCC=DDDEE139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG140:
+          componentId: AA+BBCCC=DDDEE140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG141:
+          componentId: AA+BBCCC=DDDEE141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG142:
+          componentId: AA+BBCCC=DDDEE142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG143:
+          componentId: AA+BBCCC=DDDEE143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG144:
+          componentId: AA+BBCCC=DDDEE144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG145:
+          componentId: AA+BBCCC=DDDEE145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG146:
+          componentId: AA+BBCCC=DDDEE146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG147:
+          componentId: AA+BBCCC=DDDEE147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG148:
+          componentId: AA+BBCCC=DDDEE148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG149:
+          componentId: AA+BBCCC=DDDEE149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG150:
+          componentId: AA+BBCCC=DDDEE150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG151:
+          componentId: AA+BBCCC=DDDEE151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG152:
+          componentId: AA+BBCCC=DDDEE152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG153:
+          componentId: AA+BBCCC=DDDEE153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG154:
+          componentId: AA+BBCCC=DDDEE154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG155:
+          componentId: AA+BBCCC=DDDEE155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG156:
+          componentId: AA+BBCCC=DDDEE156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG157:
+          componentId: AA+BBCCC=DDDEE157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG158:
+          componentId: AA+BBCCC=DDDEE158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG159:
+          componentId: AA+BBCCC=DDDEE159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG160:
+          componentId: AA+BBCCC=DDDEE160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG161:
+          componentId: AA+BBCCC=DDDEE161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG162:
+          componentId: AA+BBCCC=DDDEE162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG163:
+          componentId: AA+BBCCC=DDDEE163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG164:
+          componentId: AA+BBCCC=DDDEE164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG165:
+          componentId: AA+BBCCC=DDDEE165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG166:
+          componentId: AA+BBCCC=DDDEE166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG167:
+          componentId: AA+BBCCC=DDDEE167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG168:
+          componentId: AA+BBCCC=DDDEE168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG169:
+          componentId: AA+BBCCC=DDDEE169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG170:
+          componentId: AA+BBCCC=DDDEE170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG171:
+          componentId: AA+BBCCC=DDDEE171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG172:
+          componentId: AA+BBCCC=DDDEE172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG173:
+          componentId: AA+BBCCC=DDDEE173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG174:
+          componentId: AA+BBCCC=DDDEE174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG175:
+          componentId: AA+BBCCC=DDDEE175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG176:
+          componentId: AA+BBCCC=DDDEE176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG177:
+          componentId: AA+BBCCC=DDDEE177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG178:
+          componentId: AA+BBCCC=DDDEE178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG179:
+          componentId: AA+BBCCC=DDDEE179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG180:
+          componentId: AA+BBCCC=DDDEE180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG181:
+          componentId: AA+BBCCC=DDDEE181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG182:
+          componentId: AA+BBCCC=DDDEE182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG183:
+          componentId: AA+BBCCC=DDDEE183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG184:
+          componentId: AA+BBCCC=DDDEE184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG185:
+          componentId: AA+BBCCC=DDDEE185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG186:
+          componentId: AA+BBCCC=DDDEE186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG187:
+          componentId: AA+BBCCC=DDDEE187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG188:
+          componentId: AA+BBCCC=DDDEE188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG189:
+          componentId: AA+BBCCC=DDDEE189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG190:
+          componentId: AA+BBCCC=DDDEE190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG191:
+          componentId: AA+BBCCC=DDDEE191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG192:
+          componentId: AA+BBCCC=DDDEE192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG193:
+          componentId: AA+BBCCC=DDDEE193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG194:
+          componentId: AA+BBCCC=DDDEE194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG195:
+          componentId: AA+BBCCC=DDDEE195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG196:
+          componentId: AA+BBCCC=DDDEE196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG197:
+          componentId: AA+BBCCC=DDDEE197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG198:
+          componentId: AA+BBCCC=DDDEE198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG199:
+          componentId: AA+BBCCC=DDDEE199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG200:
+          componentId: AA+BBCCC=DDDEE200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG201:
+          componentId: AA+BBCCC=DDDEE201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG202:
+          componentId: AA+BBCCC=DDDEE202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG203:
+          componentId: AA+BBCCC=DDDEE203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG204:
+          componentId: AA+BBCCC=DDDEE204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG205:
+          componentId: AA+BBCCC=DDDEE205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG206:
+          componentId: AA+BBCCC=DDDEE206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG207:
+          componentId: AA+BBCCC=DDDEE207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG208:
+          componentId: AA+BBCCC=DDDEE208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG209:
+          componentId: AA+BBCCC=DDDEE209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG210:
+          componentId: AA+BBCCC=DDDEE210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG211:
+          componentId: AA+BBCCC=DDDEE211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG212:
+          componentId: AA+BBCCC=DDDEE212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG213:
+          componentId: AA+BBCCC=DDDEE213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG214:
+          componentId: AA+BBCCC=DDDEE214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG215:
+          componentId: AA+BBCCC=DDDEE215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG216:
+          componentId: AA+BBCCC=DDDEE216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG217:
+          componentId: AA+BBCCC=DDDEE217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG218:
+          componentId: AA+BBCCC=DDDEE218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG219:
+          componentId: AA+BBCCC=DDDEE219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG220:
+          componentId: AA+BBCCC=DDDEE220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG221:
+          componentId: AA+BBCCC=DDDEE221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG222:
+          componentId: AA+BBCCC=DDDEE222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG223:
+          componentId: AA+BBCCC=DDDEE223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG224:
+          componentId: AA+BBCCC=DDDEE224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG225:
+          componentId: AA+BBCCC=DDDEE225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG226:
+          componentId: AA+BBCCC=DDDEE226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG227:
+          componentId: AA+BBCCC=DDDEE227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG228:
+          componentId: AA+BBCCC=DDDEE228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG229:
+          componentId: AA+BBCCC=DDDEE229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG230:
+          componentId: AA+BBCCC=DDDEE230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG231:
+          componentId: AA+BBCCC=DDDEE231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG232:
+          componentId: AA+BBCCC=DDDEE232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG233:
+          componentId: AA+BBCCC=DDDEE233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG234:
+          componentId: AA+BBCCC=DDDEE234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG235:
+          componentId: AA+BBCCC=DDDEE235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG236:
+          componentId: AA+BBCCC=DDDEE236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG237:
+          componentId: AA+BBCCC=DDDEE237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG238:
+          componentId: AA+BBCCC=DDDEE238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG239:
+          componentId: AA+BBCCC=DDDEE239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG240:
+          componentId: AA+BBCCC=DDDEE240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG241:
+          componentId: AA+BBCCC=DDDEE241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG242:
+          componentId: AA+BBCCC=DDDEE242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG243:
+          componentId: AA+BBCCC=DDDEE243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG244:
+          componentId: AA+BBCCC=DDDEE244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG245:
+          componentId: AA+BBCCC=DDDEE245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG246:
+          componentId: AA+BBCCC=DDDEE246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG247:
+          componentId: AA+BBCCC=DDDEE247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG248:
+          componentId: AA+BBCCC=DDDEE248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG249:
+          componentId: AA+BBCCC=DDDEE249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG250:
+          componentId: AA+BBCCC=DDDEE250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG251:
+          componentId: AA+BBCCC=DDDEE251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG252:
+          componentId: AA+BBCCC=DDDEE252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG253:
+          componentId: AA+BBCCC=DDDEE253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG254:
+          componentId: AA+BBCCC=DDDEE254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        SG255:
+          componentId: AA+BBCCC=DDDEE255
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+      Detector logic:
+        DL1:
+          componentId: AA+BBCCC=DDDDLAA1
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL2:
+          componentId: AA+BBCCC=DDDDLAA2
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL3:
+          componentId: AA+BBCCC=DDDDLAA3
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL4:
+          componentId: AA+BBCCC=DDDDLAA4
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL5:
+          componentId: AA+BBCCC=DDDDLAA5
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL6:
+          componentId: AA+BBCCC=DDDDLAA6
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL7:
+          componentId: AA+BBCCC=DDDDLAA7
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL8:
+          componentId: AA+BBCCC=DDDDLAA8
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL9:
+          componentId: AA+BBCCC=DDDDLAA9
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL10:
+          componentId: AA+BBCCC=DDDDLA10
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL11:
+          componentId: AA+BBCCC=DDDDLA11
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL12:
+          componentId: AA+BBCCC=DDDDLA12
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL13:
+          componentId: AA+BBCCC=DDDDLA13
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL14:
+          componentId: AA+BBCCC=DDDDLA14
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL15:
+          componentId: AA+BBCCC=DDDDLA15
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL16:
+          componentId: AA+BBCCC=DDDDLA16
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL17:
+          componentId: AA+BBCCC=DDDDLA17
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL18:
+          componentId: AA+BBCCC=DDDDLA18
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL19:
+          componentId: AA+BBCCC=DDDDLA19
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL20:
+          componentId: AA+BBCCC=DDDDLA20
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL21:
+          componentId: AA+BBCCC=DDDDLA21
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL22:
+          componentId: AA+BBCCC=DDDDLA22
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL23:
+          componentId: AA+BBCCC=DDDDLA23
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL24:
+          componentId: AA+BBCCC=DDDDLA24
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL25:
+          componentId: AA+BBCCC=DDDDLA25
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL26:
+          componentId: AA+BBCCC=DDDDLA26
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL27:
+          componentId: AA+BBCCC=DDDDLA27
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL28:
+          componentId: AA+BBCCC=DDDDLA28
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL29:
+          componentId: AA+BBCCC=DDDDLA29
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL30:
+          componentId: AA+BBCCC=DDDDLA30
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL31:
+          componentId: AA+BBCCC=DDDDLA31
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL32:
+          componentId: AA+BBCCC=DDDDLA32
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL33:
+          componentId: AA+BBCCC=DDDDLA33
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL34:
+          componentId: AA+BBCCC=DDDDLA34
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL35:
+          componentId: AA+BBCCC=DDDDLA35
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL36:
+          componentId: AA+BBCCC=DDDDLA36
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL37:
+          componentId: AA+BBCCC=DDDDLA37
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL38:
+          componentId: AA+BBCCC=DDDDLA38
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL39:
+          componentId: AA+BBCCC=DDDDLA39
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL40:
+          componentId: AA+BBCCC=DDDDLA40
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL41:
+          componentId: AA+BBCCC=DDDDLA41
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL42:
+          componentId: AA+BBCCC=DDDDLA42
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL43:
+          componentId: AA+BBCCC=DDDDLA43
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL44:
+          componentId: AA+BBCCC=DDDDLA44
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL45:
+          componentId: AA+BBCCC=DDDDLA45
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL46:
+          componentId: AA+BBCCC=DDDDLA46
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL47:
+          componentId: AA+BBCCC=DDDDLA47
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL48:
+          componentId: AA+BBCCC=DDDDLA48
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL49:
+          componentId: AA+BBCCC=DDDDLA49
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL50:
+          componentId: AA+BBCCC=DDDDLA50
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL51:
+          componentId: AA+BBCCC=DDDDLA51
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL52:
+          componentId: AA+BBCCC=DDDDLA52
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL53:
+          componentId: AA+BBCCC=DDDDLA53
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL54:
+          componentId: AA+BBCCC=DDDDLA54
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL55:
+          componentId: AA+BBCCC=DDDDLA55
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL56:
+          componentId: AA+BBCCC=DDDDLA56
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL57:
+          componentId: AA+BBCCC=DDDDLA57
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL58:
+          componentId: AA+BBCCC=DDDDLA58
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL59:
+          componentId: AA+BBCCC=DDDDLA59
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL60:
+          componentId: AA+BBCCC=DDDDLA60
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL61:
+          componentId: AA+BBCCC=DDDDLA61
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL62:
+          componentId: AA+BBCCC=DDDDLA62
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL63:
+          componentId: AA+BBCCC=DDDDLA63
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL64:
+          componentId: AA+BBCCC=DDDDLA64
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL65:
+          componentId: AA+BBCCC=DDDDLA65
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL66:
+          componentId: AA+BBCCC=DDDDLA66
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL67:
+          componentId: AA+BBCCC=DDDDLA67
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL68:
+          componentId: AA+BBCCC=DDDDLA68
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL69:
+          componentId: AA+BBCCC=DDDDLA69
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL70:
+          componentId: AA+BBCCC=DDDDLA70
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL71:
+          componentId: AA+BBCCC=DDDDLA71
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL72:
+          componentId: AA+BBCCC=DDDDLA72
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL73:
+          componentId: AA+BBCCC=DDDDLA73
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL74:
+          componentId: AA+BBCCC=DDDDLA74
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL75:
+          componentId: AA+BBCCC=DDDDLA75
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL76:
+          componentId: AA+BBCCC=DDDDLA76
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL77:
+          componentId: AA+BBCCC=DDDDLA77
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL78:
+          componentId: AA+BBCCC=DDDDLA78
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL79:
+          componentId: AA+BBCCC=DDDDLA79
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL80:
+          componentId: AA+BBCCC=DDDDLA80
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL81:
+          componentId: AA+BBCCC=DDDDLA81
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL82:
+          componentId: AA+BBCCC=DDDDLA82
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL83:
+          componentId: AA+BBCCC=DDDDLA83
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL84:
+          componentId: AA+BBCCC=DDDDLA84
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL85:
+          componentId: AA+BBCCC=DDDDLA85
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL86:
+          componentId: AA+BBCCC=DDDDLA86
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL87:
+          componentId: AA+BBCCC=DDDDLA87
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL88:
+          componentId: AA+BBCCC=DDDDLA88
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL89:
+          componentId: AA+BBCCC=DDDDLA89
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL90:
+          componentId: AA+BBCCC=DDDDLA90
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL91:
+          componentId: AA+BBCCC=DDDDLA91
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL92:
+          componentId: AA+BBCCC=DDDDLA92
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL93:
+          componentId: AA+BBCCC=DDDDLA93
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL94:
+          componentId: AA+BBCCC=DDDDLA94
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL95:
+          componentId: AA+BBCCC=DDDDLA95
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL96:
+          componentId: AA+BBCCC=DDDDLA96
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL97:
+          componentId: AA+BBCCC=DDDDLA97
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL98:
+          componentId: AA+BBCCC=DDDDLA98
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL99:
+          componentId: AA+BBCCC=DDDDLA99
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL100:
+          componentId: AA+BBCCC=DDDDL100
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL101:
+          componentId: AA+BBCCC=DDDDL101
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL102:
+          componentId: AA+BBCCC=DDDDL102
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL103:
+          componentId: AA+BBCCC=DDDDL103
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL104:
+          componentId: AA+BBCCC=DDDDL104
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL105:
+          componentId: AA+BBCCC=DDDDL105
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL106:
+          componentId: AA+BBCCC=DDDDL106
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL107:
+          componentId: AA+BBCCC=DDDDL107
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL108:
+          componentId: AA+BBCCC=DDDDL108
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL109:
+          componentId: AA+BBCCC=DDDDL109
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL110:
+          componentId: AA+BBCCC=DDDDL110
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL111:
+          componentId: AA+BBCCC=DDDDL111
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL112:
+          componentId: AA+BBCCC=DDDDL112
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL113:
+          componentId: AA+BBCCC=DDDDL113
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL114:
+          componentId: AA+BBCCC=DDDDL114
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL115:
+          componentId: AA+BBCCC=DDDDL115
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL116:
+          componentId: AA+BBCCC=DDDDL116
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL117:
+          componentId: AA+BBCCC=DDDDL117
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL118:
+          componentId: AA+BBCCC=DDDDL118
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL119:
+          componentId: AA+BBCCC=DDDDL119
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL120:
+          componentId: AA+BBCCC=DDDDL120
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL121:
+          componentId: AA+BBCCC=DDDDL121
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL122:
+          componentId: AA+BBCCC=DDDDL122
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL123:
+          componentId: AA+BBCCC=DDDDL123
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL124:
+          componentId: AA+BBCCC=DDDDL124
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL125:
+          componentId: AA+BBCCC=DDDDL125
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL126:
+          componentId: AA+BBCCC=DDDDL126
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL127:
+          componentId: AA+BBCCC=DDDDL127
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL128:
+          componentId: AA+BBCCC=DDDDL128
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL129:
+          componentId: AA+BBCCC=DDDDL129
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL130:
+          componentId: AA+BBCCC=DDDDL130
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL131:
+          componentId: AA+BBCCC=DDDDL131
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL132:
+          componentId: AA+BBCCC=DDDDL132
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL133:
+          componentId: AA+BBCCC=DDDDL133
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL134:
+          componentId: AA+BBCCC=DDDDL134
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL135:
+          componentId: AA+BBCCC=DDDDL135
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL136:
+          componentId: AA+BBCCC=DDDDL136
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL137:
+          componentId: AA+BBCCC=DDDDL137
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL138:
+          componentId: AA+BBCCC=DDDDL138
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL139:
+          componentId: AA+BBCCC=DDDDL139
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL140:
+          componentId: AA+BBCCC=DDDDL140
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL141:
+          componentId: AA+BBCCC=DDDDL141
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL142:
+          componentId: AA+BBCCC=DDDDL142
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL143:
+          componentId: AA+BBCCC=DDDDL143
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL144:
+          componentId: AA+BBCCC=DDDDL144
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL145:
+          componentId: AA+BBCCC=DDDDL145
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL146:
+          componentId: AA+BBCCC=DDDDL146
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL147:
+          componentId: AA+BBCCC=DDDDL147
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL148:
+          componentId: AA+BBCCC=DDDDL148
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL149:
+          componentId: AA+BBCCC=DDDDL149
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL150:
+          componentId: AA+BBCCC=DDDDL150
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL151:
+          componentId: AA+BBCCC=DDDDL151
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL152:
+          componentId: AA+BBCCC=DDDDL152
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL153:
+          componentId: AA+BBCCC=DDDDL153
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL154:
+          componentId: AA+BBCCC=DDDDL154
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL155:
+          componentId: AA+BBCCC=DDDDL155
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL156:
+          componentId: AA+BBCCC=DDDDL156
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL157:
+          componentId: AA+BBCCC=DDDDL157
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL158:
+          componentId: AA+BBCCC=DDDDL158
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL159:
+          componentId: AA+BBCCC=DDDDL159
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL160:
+          componentId: AA+BBCCC=DDDDL160
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL161:
+          componentId: AA+BBCCC=DDDDL161
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL162:
+          componentId: AA+BBCCC=DDDDL162
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL163:
+          componentId: AA+BBCCC=DDDDL163
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL164:
+          componentId: AA+BBCCC=DDDDL164
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL165:
+          componentId: AA+BBCCC=DDDDL165
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL166:
+          componentId: AA+BBCCC=DDDDL166
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL167:
+          componentId: AA+BBCCC=DDDDL167
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL168:
+          componentId: AA+BBCCC=DDDDL168
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL169:
+          componentId: AA+BBCCC=DDDDL169
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL170:
+          componentId: AA+BBCCC=DDDDL170
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL171:
+          componentId: AA+BBCCC=DDDDL171
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL172:
+          componentId: AA+BBCCC=DDDDL172
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL173:
+          componentId: AA+BBCCC=DDDDL173
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL174:
+          componentId: AA+BBCCC=DDDDL174
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL175:
+          componentId: AA+BBCCC=DDDDL175
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL176:
+          componentId: AA+BBCCC=DDDDL176
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL177:
+          componentId: AA+BBCCC=DDDDL177
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL178:
+          componentId: AA+BBCCC=DDDDL178
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL179:
+          componentId: AA+BBCCC=DDDDL179
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL180:
+          componentId: AA+BBCCC=DDDDL180
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL181:
+          componentId: AA+BBCCC=DDDDL181
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL182:
+          componentId: AA+BBCCC=DDDDL182
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL183:
+          componentId: AA+BBCCC=DDDDL183
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL184:
+          componentId: AA+BBCCC=DDDDL184
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL185:
+          componentId: AA+BBCCC=DDDDL185
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL186:
+          componentId: AA+BBCCC=DDDDL186
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL187:
+          componentId: AA+BBCCC=DDDDL187
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL188:
+          componentId: AA+BBCCC=DDDDL188
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL189:
+          componentId: AA+BBCCC=DDDDL189
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL190:
+          componentId: AA+BBCCC=DDDDL190
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL191:
+          componentId: AA+BBCCC=DDDDL191
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL192:
+          componentId: AA+BBCCC=DDDDL192
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL193:
+          componentId: AA+BBCCC=DDDDL193
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL194:
+          componentId: AA+BBCCC=DDDDL194
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL195:
+          componentId: AA+BBCCC=DDDDL195
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL196:
+          componentId: AA+BBCCC=DDDDL196
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL197:
+          componentId: AA+BBCCC=DDDDL197
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL198:
+          componentId: AA+BBCCC=DDDDL198
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL199:
+          componentId: AA+BBCCC=DDDDL199
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL200:
+          componentId: AA+BBCCC=DDDDL200
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL201:
+          componentId: AA+BBCCC=DDDDL201
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL202:
+          componentId: AA+BBCCC=DDDDL202
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL203:
+          componentId: AA+BBCCC=DDDDL203
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL204:
+          componentId: AA+BBCCC=DDDDL204
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL205:
+          componentId: AA+BBCCC=DDDDL205
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL206:
+          componentId: AA+BBCCC=DDDDL206
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL207:
+          componentId: AA+BBCCC=DDDDL207
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL208:
+          componentId: AA+BBCCC=DDDDL208
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL209:
+          componentId: AA+BBCCC=DDDDL209
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL210:
+          componentId: AA+BBCCC=DDDDL210
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL211:
+          componentId: AA+BBCCC=DDDDL211
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL212:
+          componentId: AA+BBCCC=DDDDL212
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL213:
+          componentId: AA+BBCCC=DDDDL213
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL214:
+          componentId: AA+BBCCC=DDDDL214
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL215:
+          componentId: AA+BBCCC=DDDDL215
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL216:
+          componentId: AA+BBCCC=DDDDL216
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL217:
+          componentId: AA+BBCCC=DDDDL217
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL218:
+          componentId: AA+BBCCC=DDDDL218
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL219:
+          componentId: AA+BBCCC=DDDDL219
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL220:
+          componentId: AA+BBCCC=DDDDL220
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL221:
+          componentId: AA+BBCCC=DDDDL221
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL222:
+          componentId: AA+BBCCC=DDDDL222
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL223:
+          componentId: AA+BBCCC=DDDDL223
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL224:
+          componentId: AA+BBCCC=DDDDL224
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL225:
+          componentId: AA+BBCCC=DDDDL225
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL226:
+          componentId: AA+BBCCC=DDDDL226
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL227:
+          componentId: AA+BBCCC=DDDDL227
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL228:
+          componentId: AA+BBCCC=DDDDL228
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL229:
+          componentId: AA+BBCCC=DDDDL229
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL230:
+          componentId: AA+BBCCC=DDDDL230
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL231:
+          componentId: AA+BBCCC=DDDDL231
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL232:
+          componentId: AA+BBCCC=DDDDL232
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL233:
+          componentId: AA+BBCCC=DDDDL233
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL234:
+          componentId: AA+BBCCC=DDDDL234
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL235:
+          componentId: AA+BBCCC=DDDDL235
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL236:
+          componentId: AA+BBCCC=DDDDL236
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL237:
+          componentId: AA+BBCCC=DDDDL237
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL238:
+          componentId: AA+BBCCC=DDDDL238
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL239:
+          componentId: AA+BBCCC=DDDDL239
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL240:
+          componentId: AA+BBCCC=DDDDL240
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL241:
+          componentId: AA+BBCCC=DDDDL241
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL242:
+          componentId: AA+BBCCC=DDDDL242
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL243:
+          componentId: AA+BBCCC=DDDDL243
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL244:
+          componentId: AA+BBCCC=DDDDL244
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL245:
+          componentId: AA+BBCCC=DDDDL245
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL246:
+          componentId: AA+BBCCC=DDDDL246
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL247:
+          componentId: AA+BBCCC=DDDDL247
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL248:
+          componentId: AA+BBCCC=DDDDL248
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL249:
+          componentId: AA+BBCCC=DDDDL249
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL250:
+          componentId: AA+BBCCC=DDDDL250
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL251:
+          componentId: AA+BBCCC=DDDDL251
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL252:
+          componentId: AA+BBCCC=DDDDL252
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL253:
+          componentId: AA+BBCCC=DDDDL253
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL254:
+          componentId: AA+BBCCC=DDDDL254
+          ntsObjectId: AA+BBCCC=DDDEEFFF
+        DL255:
+          componentId: AA+BBCCC=DDDDL255
+          ntsObjectId: AA+BBCCC=DDDEEFFF


### PR DESCRIPTION
The YAML examples all used the same metadata and site information. That included version number and date.
