### PR TITLE
Use "Send aggregated status when connecting" by default in 3.1.2

### DIFF
--- a/RSMPCommon/RSMPGS_Helper.cs
+++ b/RSMPCommon/RSMPGS_Helper.cs
@@ -535,7 +535,7 @@ namespace nsRSMPGS
       AddSetting("ClearSubscriptionsAtDisconnect", "Clear subscriptions when disconnecting", true, true, false, false, false, false, false);
       AddSetting("AllowRequestsOfAlarmsAndAggStatus", "Allow alarms and aggregated status Request messages", false, false, false, false, true, true, true);
       AddSetting("Buffer10000Messages", "Buffer up to 10000 messages (instead of 1000)", false, false, false, true, true, true, true);
-      AddSetting("SendAggregatedStatusAtConnect", "Send aggregated status when connecting", false, false, true, true, true, true, true);
+      AddSetting("SendAggregatedStatusAtConnect", "Send aggregated status when connecting", false, true, true, true, true, true, true);
       AddSetting("SendAllAlarmsWhenConnect", "Send all alarms when connecting", false, false, true, true, true, true, true);
       AddSetting("BufferAndSendAlarmsWhenConnect", "Buffer alarm events when disconnected and send them when connecting", false, false, true, true, true, true, true);
       AddSetting("BufferAndSendAggregatedStatusWhenConnect", "Buffer aggregated status when disconnected and send them when connecting", false, false, true, true, true, true, true);

--- a/RSMPGS1/RSMPGS1.cs
+++ b/RSMPGS1/RSMPGS1.cs
@@ -60,7 +60,7 @@ using System.Security.Authentication;
 //                           / Don't resend unacked packets by default #76
 //                           / Create a new GUID when resending a packet #77
 //                           / Include SXL 1.0.7 #78
-// 24.xx.xx / DO / 1.0.6 
+// 24.xx.xx / DO / 1.0.6     / Use "Send aggregated status when connecting" by default in 3.1.2
 //
 //
 // ---------------------------------------------------------------------------------------------------

--- a/RSMPGS2/RSMPGS2.cs
+++ b/RSMPGS2/RSMPGS2.cs
@@ -53,7 +53,7 @@ using System.Security.Authentication;
 //                           / Don't resend unacked packets by default #76
 //                           / Create a new GUID when resending a packet #77
 //                           / Include SXL 1.0.7 #78
-// 24.xx.xx / DO / 1.0.6 
+// 24.xx.xx / DO / 1.0.6     / Use "Send aggregated status when connecting" by default in 3.1.2
 //
 //
 // ---------------------------------------------------------------------------------------------------

--- a/Settings/RSMPGS1.INI
+++ b/Settings/RSMPGS1.INI
@@ -172,7 +172,7 @@ AllowRequestsOfAlarmsAndAggStatus=0
 UseCaseSensitiveValue=0
 [Behaviour_RSMP_3_1_2]
 AllowUseRSMPVersion=1
-SendAggregatedStatusAtConnect=0
+SendAggregatedStatusAtConnect=1
 SendAllAlarmsWhenConnect=0
 BufferAndSendAlarmsWhenConnect=0
 BufferAndSendAggregatedStatusWhenConnect=0


### PR DESCRIPTION
Enable the option "Send aggregated status when connecting" by default for version 3.1.2.