### PR TITLE
Replace "SUL" with "SXL"

### DIFF
--- a/Documents/Manual_RSMPGS1.rst
+++ b/Documents/Manual_RSMPGS1.rst
@@ -403,15 +403,15 @@ When RSMPGS1 is connected to the supervision system, information about SXL and
 the RSMP-interface version is sent over for the software to determine whether
 communication is possible or not.
 
-**Active SXL (SUL) version to be used when connecting**
+**Active SXL version to be used when connecting**
 
 SXL version which is sent over via the protocol when connection is made.
 
-**SXL (SUL) version found in file**
+**SXL version found in file**
 
 SXL version which is found in reference files in ``.\Objects`` folder.
 
-**Always use SXL (SUL) version from file (if found)**
+**Always use SXL version from file (if found)**
 
 Select to always use version number from the SXL files in protocol negotiation.
 

--- a/Documents/Manual_RSMPGS2.rst
+++ b/Documents/Manual_RSMPGS2.rst
@@ -408,15 +408,15 @@ When a connection is established, information about SXL and
 the RSMP-interface version is sent over for the software to determine whether
 communication is possible or not.
 
-**Active SXL (SUL) version to be used when connecting**
+**Active SXL version to be used when connecting**
 
 SXL version which is sent over via the protocol when connection is made.
 
-**SXL (SUL) version found in file**
+**SXL version found in file**
 
 SXL version which is found in reference files in ``.\Objects`` folder.
 
-**Always use SXL (SUL) version from file (if found)**
+**Always use SXL version from file (if found)**
 
 Select to always use version number from the SXL files in protocol negotiation.
 

--- a/RSMPCommon/RSMPGS_Helper.cs
+++ b/RSMPCommon/RSMPGS_Helper.cs
@@ -531,7 +531,7 @@ namespace nsRSMPGS
       AddSetting("AllowUseRSMPVersion", "Allow/use RSMP version in protocol negotiation", true, true, true, true, true, true, true, true);
 
       AddSetting("SendVersionInfoAtConnect", "Send and expect version info when connecting", true);
-      AddSetting("SXL_VersionIgnore", "Ignore client RSMP and SXL (SUL) version incompability", false);
+      AddSetting("SXL_VersionIgnore", "Ignore client RSMP and SXL version incompability", false);
       AddSetting("SendWatchdogPacketAtStartup", "Send and expect Watchdog packet when connecting", true);
 
       /*

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -780,7 +780,7 @@ namespace nsRSMPGS
       if (bSXLVersionIsOk == false)
       {
         RSMPGS.SysLog.SysLog(cHelper.IsSettingChecked("SXL_VersionIgnore") ? cSysLogAndDebug.Severity.Warning : cSysLogAndDebug.Severity.Error,
-          "Client SXL (SUL) version is not compatible");
+          "Client SXL version is not compatible");
       }
 
       if (HighestRSMPVersion == RSMPVersion.NotSupported || bSXLVersionIsOk == false)

--- a/RSMPCommon/RSMPGS_Main.cs
+++ b/RSMPCommon/RSMPGS_Main.cs
@@ -546,9 +546,9 @@ namespace nsRSMPGS
         listView_AlarmEvents.Columns.Add("Value", 100, HorizontalAlignment.Center);
       }
 
-      if (RSMPGS.ProcessImage.sSULRevision.Length > 0)
+      if (RSMPGS.ProcessImage.sSXLRevision.Length > 0)
       {
-        RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Info, "Signal Exchange List revision number from file is '{0}'", RSMPGS.ProcessImage.sSULRevision);
+        RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Info, "Signal Exchange List revision number from file is '{0}'", RSMPGS.ProcessImage.sSXLRevision);
       }
       else
       {
@@ -557,7 +557,7 @@ namespace nsRSMPGS
 
       textBox_SignalExchangeListVersion.Text = cPrivateProfile.GetIniFileString("Main", "SignalExchangeListVersion", "").Trim();
 
-      textBox_SignalExchangeListVersionFromFile.Text = RSMPGS.ProcessImage.sSULRevision;
+      textBox_SignalExchangeListVersionFromFile.Text = RSMPGS.ProcessImage.sSXLRevision;
 
       if (checkBox_AlwaysUseSXLFromFile.Checked == true && textBox_SignalExchangeListVersionFromFile.Text.Length > 0)
       {
@@ -570,15 +570,15 @@ namespace nsRSMPGS
         if (RSMPGS.ProcessImage.ObjectFilesTimeStamp != cPrivateProfile.GetIniFileInt("Main", "ObjectFilesTimeStamp", 0) && RSMPGS.ProcessImage.ObjectFilesTimeStamp != 0)
         {
           string sLastSXLRevisionFromFile = cPrivateProfile.GetIniFileString("Main", "LastSXLRevisionFromFile", "");
-          if (RSMPGS.ProcessImage.sSULRevision.Length > 0 && sLastSXLRevisionFromFile.Length > 0)
+          if (RSMPGS.ProcessImage.sSXLRevision.Length > 0 && sLastSXLRevisionFromFile.Length > 0)
           {
-            if (RSMPGS.ProcessImage.sSULRevision.Equals(sLastSXLRevisionFromFile, StringComparison.OrdinalIgnoreCase))
+            if (RSMPGS.ProcessImage.sSXLRevision.Equals(sLastSXLRevisionFromFile, StringComparison.OrdinalIgnoreCase))
             {
-              System.Windows.Forms.MessageBox.Show("Signal Exchange List files have been updated, however the version number found in file (" + RSMPGS.ProcessImage.sSULRevision + ") is still the same.", "RSMPGS2", MessageBoxButtons.OK, MessageBoxIcon.Information);
+              System.Windows.Forms.MessageBox.Show("Signal Exchange List files have been updated, however the version number found in file (" + RSMPGS.ProcessImage.sSXLRevision + ") is still the same.", "RSMPGS2", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
           }
           cPrivateProfile.WriteIniFileInt("Main", "ObjectFilesTimeStamp", RSMPGS.ProcessImage.ObjectFilesTimeStamp);
-          cPrivateProfile.WriteIniFileString("Main", "LastSXLRevisionFromFile", RSMPGS.ProcessImage.sSULRevision);
+          cPrivateProfile.WriteIniFileString("Main", "LastSXLRevisionFromFile", RSMPGS.ProcessImage.sSXLRevision);
         }
       }
 

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -291,7 +291,7 @@ namespace RSMP_Messages
     public List<Version_RSMP> RSMP; // Versions
     public List<SiteId> siteId; // SiteId's
 
-    public string SXL;  // SUL (Signal Exchange List)
+    public string SXL;  // Signal Exchange List
   }
 
   public class Version_RSMP

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -138,7 +138,7 @@ namespace nsRSMPGS
     public bool bSuspended = false;
     public bool bAcknowledged = false;
     public string sObjectType;
-    public string sSpecificObject; // Optional, if set must match object in SUL
+    public string sSpecificObject; // Optional, if set must match object in SXL
     public string sAlarmCodeId;
     public DateTime sTimestamp;
     public string sDescription;
@@ -283,7 +283,7 @@ namespace nsRSMPGS
     // Object type;Object (optional);Description;commandCodeId;name;command;type;value;Comment;name;command;type;value;Comment;
 
     public string sObjectType;
-    public string sSpecificObject; // Optional, if set must match object in SUL
+    public string sSpecificObject; // Optional, if set must match object in SXL
     public string sCommandCodeId;
     public string sDescription;
     public cRoadSideObject RoadSideObject;
@@ -394,7 +394,7 @@ namespace nsRSMPGS
     // Object type;Object (optional);statusCodeId;description;name;type;value;Comment;name;type;value;Comment;name;type;value;Comment;name;type;value;Comment;name;type;value;Comment;name;type;value;Comment
 
     public string sObjectType;
-    public string sSpecificObject; // Optional, if set must match object in SUL
+    public string sSpecificObject; // Optional, if set must match object in SXL
     public string sStatusCodeId;
     public string sDescription;
 

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -48,7 +48,7 @@ namespace nsRSMPGS
 
     public int MaxAlarmReturnValues = 0;
 
-    public string sSULRevision = "";
+    public string sSXLRevision = "";
     public int ObjectFilesTimeStamp = 0;
 
 #if _RSMPGS1
@@ -78,7 +78,7 @@ namespace nsRSMPGS
       StatusObjects.Clear();
       AggregatedStatusObjects.Clear();
       MaxAlarmReturnValues = 0;
-      sSULRevision = "";
+      sSXLRevision = "";
       ObjectFilesTimeStamp = 0;
       ValueTypeObjects.Clear();
 
@@ -130,7 +130,7 @@ namespace nsRSMPGS
 
       // ProcessImage.sId = YAML.GetScalar("id");
 
-      sSULRevision = YAML.GetScalar("version");
+      sSXLRevision = YAML.GetScalar("version");
 
       //ProcessImage.sDescription = YAML.GetScalar("description");
       //ProcessImage.sConstructor = YAML.GetScalar("constructor");
@@ -1005,7 +1005,7 @@ namespace nsRSMPGS
             case SectionType_Revision:
               // ;;;;1.3;;;
               // Just take the last line...
-              sSULRevision = cHelper.Item(sLine, 1, ';').Trim();
+              sSXLRevision = cHelper.Item(sLine, 1, ';').Trim();
               break;
           }
 

--- a/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main.Designer.cs
+++ b/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main.Designer.cs
@@ -1069,7 +1069,7 @@
       this.groupBox_SXL_Version.Size = new System.Drawing.Size(700, 152);
       this.groupBox_SXL_Version.TabIndex = 0;
       this.groupBox_SXL_Version.TabStop = false;
-      this.groupBox_SXL_Version.Text = "Signal Exchange List (SXL/SUL) info";
+      this.groupBox_SXL_Version.Text = "Signal Exchange List (SXL) info";
       // 
       // checkBox_AutomaticallyLoadObjects
       // 
@@ -1090,7 +1090,7 @@
       this.label_SXL_FilePath.Name = "label_SXL_FilePath";
       this.label_SXL_FilePath.Size = new System.Drawing.Size(81, 13);
       this.label_SXL_FilePath.TabIndex = 9;
-      this.label_SXL_FilePath.Text = "SXL (SUL) path";
+      this.label_SXL_FilePath.Text = "SXL path";
       this.label_SXL_FilePath.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // textBox_SignalExchangeListPath
@@ -1110,7 +1110,7 @@
       this.checkBox_AlwaysUseSXLFromFile.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
       this.checkBox_AlwaysUseSXLFromFile.Size = new System.Drawing.Size(289, 17);
       this.checkBox_AlwaysUseSXLFromFile.TabIndex = 7;
-      this.checkBox_AlwaysUseSXLFromFile.Text = "(Always use the SXL (SUL) version from file (if found";
+      this.checkBox_AlwaysUseSXLFromFile.Text = "(Always use the SXL version from file (if found";
       this.checkBox_AlwaysUseSXLFromFile.UseVisualStyleBackColor = true;
       this.checkBox_AlwaysUseSXLFromFile.CheckedChanged += new System.EventHandler(this.checkBox_AlwaysUseSXLFromFile_CheckedChanged);
       // 
@@ -1121,7 +1121,7 @@
       this.label_SXL_VersionFromFile.Name = "label_SXL_VersionFromFile";
       this.label_SXL_VersionFromFile.Size = new System.Drawing.Size(151, 13);
       this.label_SXL_VersionFromFile.TabIndex = 6;
-      this.label_SXL_VersionFromFile.Text = "SXL (SUL) version found in file";
+      this.label_SXL_VersionFromFile.Text = "SXL version found in file";
       this.label_SXL_VersionFromFile.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // textBox_SignalExchangeListVersionFromFile
@@ -1148,7 +1148,7 @@
       this.label_SXL_VersionManually.Name = "label_SXL_VersionManually";
       this.label_SXL_VersionManually.Size = new System.Drawing.Size(265, 13);
       this.label_SXL_VersionManually.TabIndex = 0;
-      this.label_SXL_VersionManually.Text = "Active SXL (SUL) version to be used when connecting";
+      this.label_SXL_VersionManually.Text = "Active SXL version to be used when connecting";
       this.label_SXL_VersionManually.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // tabPage_RSMP

--- a/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main.cs
+++ b/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main.cs
@@ -484,12 +484,12 @@ namespace nsRSMPGS
 
     private void checkBox_AlwaysUseSXLFromFile_CheckedChanged(object sender, EventArgs e)
     {
-      if (checkBox_AlwaysUseSXLFromFile.Checked == true && RSMPGS.ProcessImage.sSULRevision.Length > 0)
+      if (checkBox_AlwaysUseSXLFromFile.Checked == true && RSMPGS.ProcessImage.sSXLRevision.Length > 0)
       {
-        if (textBox_SignalExchangeListVersion.Text.Equals(RSMPGS.ProcessImage.sSULRevision, StringComparison.OrdinalIgnoreCase) == false)
+        if (textBox_SignalExchangeListVersion.Text.Equals(RSMPGS.ProcessImage.sSXLRevision, StringComparison.OrdinalIgnoreCase) == false)
         {
-          RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Signal Exchange List revision number was set to the file version '{0}'", RSMPGS.ProcessImage.sSULRevision, textBox_SignalExchangeListVersion.Text);
-          textBox_SignalExchangeListVersion.Text = RSMPGS.ProcessImage.sSULRevision;
+          RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Signal Exchange List revision number was set to the file version '{0}'", RSMPGS.ProcessImage.sSXLRevision, textBox_SignalExchangeListVersion.Text);
+          textBox_SignalExchangeListVersion.Text = RSMPGS.ProcessImage.sSXLRevision;
         }
         textBox_SignalExchangeListVersion.Enabled = false;
       }

--- a/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main.Designer.cs
+++ b/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main.Designer.cs
@@ -1013,7 +1013,7 @@
       this.groupBox_SXL_Version.Size = new System.Drawing.Size(669, 161);
       this.groupBox_SXL_Version.TabIndex = 2;
       this.groupBox_SXL_Version.TabStop = false;
-      this.groupBox_SXL_Version.Text = "Signal Exchange List (SXL/SUL) info";
+      this.groupBox_SXL_Version.Text = "Signal Exchange List (SXL) info";
       // 
       // checkBox_AutomaticallyLoadObjects
       // 
@@ -1034,7 +1034,7 @@
       this.label_SXL_FilePath.Name = "label_SXL_FilePath";
       this.label_SXL_FilePath.Size = new System.Drawing.Size(81, 13);
       this.label_SXL_FilePath.TabIndex = 11;
-      this.label_SXL_FilePath.Text = "SXL (SUL) path";
+      this.label_SXL_FilePath.Text = "SXL path";
       this.label_SXL_FilePath.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // textBox_SignalExchangeListPath
@@ -1055,7 +1055,7 @@
       this.checkBox_AlwaysUseSXLFromFile.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
       this.checkBox_AlwaysUseSXLFromFile.Size = new System.Drawing.Size(270, 17);
       this.checkBox_AlwaysUseSXLFromFile.TabIndex = 7;
-      this.checkBox_AlwaysUseSXLFromFile.Text = "(Always use the SXL (SUL) version from file (if found";
+      this.checkBox_AlwaysUseSXLFromFile.Text = "(Always use the SXL version from file (if found";
       this.checkBox_AlwaysUseSXLFromFile.UseVisualStyleBackColor = true;
       this.checkBox_AlwaysUseSXLFromFile.CheckedChanged += new System.EventHandler(this.checkBox_AlwaysUseSXLFromFile_CheckedChanged);
       // 
@@ -1066,7 +1066,7 @@
       this.label_SXL_VersionFromFile.Name = "label_SXL_VersionFromFile";
       this.label_SXL_VersionFromFile.Size = new System.Drawing.Size(151, 13);
       this.label_SXL_VersionFromFile.TabIndex = 6;
-      this.label_SXL_VersionFromFile.Text = "SXL (SUL) version found in file";
+      this.label_SXL_VersionFromFile.Text = "SXL version found in file";
       this.label_SXL_VersionFromFile.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // textBox_SignalExchangeListVersionFromFile
@@ -1093,7 +1093,7 @@
       this.label_SXL_VersionManually.Name = "label_SXL_VersionManually";
       this.label_SXL_VersionManually.Size = new System.Drawing.Size(265, 13);
       this.label_SXL_VersionManually.TabIndex = 0;
-      this.label_SXL_VersionManually.Text = "Active SXL (SUL) version to be used when connecting";
+      this.label_SXL_VersionManually.Text = "Active SXL version to be used when connecting";
       this.label_SXL_VersionManually.TextAlign = System.Drawing.ContentAlignment.TopRight;
       // 
       // tabPage_RSMP

--- a/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main.cs
+++ b/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main.cs
@@ -281,12 +281,12 @@ namespace nsRSMPGS
 
     private void checkBox_AlwaysUseSXLFromFile_CheckedChanged(object sender, EventArgs e)
     {
-      if (checkBox_AlwaysUseSXLFromFile.Checked == true && RSMPGS.ProcessImage.sSULRevision.Length > 0)
+      if (checkBox_AlwaysUseSXLFromFile.Checked == true && RSMPGS.ProcessImage.sSXLRevision.Length > 0)
       {
-        if (textBox_SignalExchangeListVersion.Text.Equals(RSMPGS.ProcessImage.sSULRevision, StringComparison.OrdinalIgnoreCase) == false)
+        if (textBox_SignalExchangeListVersion.Text.Equals(RSMPGS.ProcessImage.sSXLRevision, StringComparison.OrdinalIgnoreCase) == false)
         {
-          RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Signal Exchange List revision number was set to the file version '{0}'", RSMPGS.ProcessImage.sSULRevision, textBox_SignalExchangeListVersion.Text);
-          textBox_SignalExchangeListVersion.Text = RSMPGS.ProcessImage.sSULRevision;
+          RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Signal Exchange List revision number was set to the file version '{0}'", RSMPGS.ProcessImage.sSXLRevision, textBox_SignalExchangeListVersion.Text);
+          textBox_SignalExchangeListVersion.Text = RSMPGS.ProcessImage.sSXLRevision;
         }
         textBox_SignalExchangeListVersion.Enabled = false;
       }


### PR DESCRIPTION
"SUL" stands for "Signalutbyteslista" in Swedish, but we've used "SXL" which stands for "Signal Exchange List" instead.