### PR TITLE
Fix support for floating point UpdateRates

### DIFF
--- a/RSMPGS1/RSMPGS1_ProcessImage.cs
+++ b/RSMPGS1/RSMPGS1_ProcessImage.cs
@@ -42,7 +42,7 @@ namespace nsRSMPGS
       {
         try
         {
-          UpdateRate = (int)fUpdateRate * 1000;
+          UpdateRate = (int)(fUpdateRate * 1000);
         }
         catch
         {


### PR DESCRIPTION
UpdateRate gets cast to integer, but the
specification defines floating point.