### PR TITLE
RSMP 3.2.2: All arguments needs to be present

### DIFF
--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -304,6 +304,7 @@ namespace nsRSMPGS
         NewCommandReturnValue.sName = CommandReturnValue.sName;
         NewCommandReturnValue.sCommand = CommandReturnValue.sCommand;
         NewCommandReturnValue.sComment = CommandReturnValue.sComment;
+        NewCommandReturnValue.bOptional = CommandReturnValue.bOptional;
         NewCommandReturnValue.Value = new cValue(CommandReturnValue.Value.ValueTypeObject, true);
 
 #if _RSMPGS2
@@ -343,6 +344,7 @@ namespace nsRSMPGS
     public string sComment;
 
     public cValue Value;
+    public Boolean bOptional;
 
 #if _RSMPGS2
 

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -542,6 +542,7 @@ namespace nsRSMPGS
                     //CommandReturnValue.sType = YAMLArgument.GetScalar("type");
                     //CommandReturnValue.sValue = YAMLArgument.GetScalar("values");
                     CommandReturnValue.sComment = YAMLArgument.GetScalar("description");
+                    CommandReturnValue.bOptional = YAMLArgument.GetScalar("optional").ToLower().Equals("true");
 
                     // Additional description can be found in "values"
                     cYAMLMapping Values;

--- a/RSMPGS1/RSMPGS1.cs
+++ b/RSMPGS1/RSMPGS1.cs
@@ -65,6 +65,7 @@ using System.Security.Authentication;
 //                           / Replace "SUL" with "SXL" #85
 //                           / Reset uRt interval when the value changes on RSMPGS 3.2.2 #86
 //                           / Fix support for floating point UpdateRates #88
+//                           / All arguments needs to be present #89
 //
 //
 // ---------------------------------------------------------------------------------------------------

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -521,22 +521,24 @@ namespace nsRSMPGS
               // Check all return values of the command object
               foreach (cCommandReturnValue cReturnValue in CommandObject.CommandReturnValues)
               {
-                // Future TODO with RSMP 3.3: Skip argument if it's optional
-
-                // Find the Returnvalue ('name') in the CommandRequest   
-                CommandRequest_Value CommandRequestValue = CommandRequest.arg.Find(name => name.n.Equals(cReturnValue.sName, sc));
-                if (CommandRequestValue == null)
-                {
-                  // Not all arguments are present
-                  sError = "Got Command, not all arguments included in cCI (NTSObjectId: " + CommandRequest.ntsOId + ", ComponentId: " + CommandRequest.cId + ", CommandCodeId: " + CommandRequest_Value.cCI + ", Name: " + CommandRequest_Value.n + ", Command: " + CommandRequest_Value.cO + ", Value: " + CommandRequest_Value.v + ")";
-                  RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
-
-                  // MessageNotAck
-                  if (!bHasSentAckOrNack)
+                // Skip check if it's optional
+                if(cReturnValue.bOptional == false)
+                { 
+                  // Find the Returnvalue ('name') in the CommandRequest   
+                  CommandRequest_Value CommandRequestValue = CommandRequest.arg.Find(name => name.n.Equals(cReturnValue.sName, sc));
+                  if (CommandRequestValue == null)
                   {
-                    bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
+                    // Not all arguments are present
+                    sError = "Got Command, not all arguments included in cCI (NTSObjectId: " + CommandRequest.ntsOId + ", ComponentId: " + CommandRequest.cId + ", CommandCodeId: " + CommandRequest_Value.cCI + ", Name: " + CommandRequest_Value.n + ", Command: " + CommandRequest_Value.cO + ", Value: " + CommandRequest_Value.v + ")";
+                    RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
+
+                    // MessageNotAck
+                    if (!bHasSentAckOrNack)
+                    {
+                      bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
+                    }
+                    return false;
                   }
-                  return false;
                 }
               }
             }

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -515,6 +515,32 @@ namespace nsRSMPGS
               return false;
             }
 
+            // RSMPGS 3.2.2: All arguments (return values) needs to be present
+            if (NegotiatedRSMPVersion >= RSMPVersion.RSMP_3_2_2)
+            {
+              // Check all return values of the command object
+              foreach (cCommandReturnValue cReturnValue in CommandObject.CommandReturnValues)
+              {
+                // Future TODO with RSMP 3.3: Skip argument if it's optional
+
+                // Find the Returnvalue ('name') in the CommandRequest   
+                CommandRequest_Value CommandRequestValue = CommandRequest.arg.Find(name => name.n.Equals(cReturnValue.sName, sc));
+                if (CommandRequestValue == null)
+                {
+                  // Not all arguments are present
+                  sError = "Got Command, not all arguments included in cCI (NTSObjectId: " + CommandRequest.ntsOId + ", ComponentId: " + CommandRequest.cId + ", CommandCodeId: " + CommandRequest_Value.cCI + ", Name: " + CommandRequest_Value.n + ", Command: " + CommandRequest_Value.cO + ", Value: " + CommandRequest_Value.v + ")";
+                  RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
+
+                  // MessageNotAck
+                  if (!bHasSentAckOrNack)
+                  {
+                    bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
+                  }
+                  return false;
+                }
+              }
+            }
+
             cCommandReturnValue CommandReturnValue = CommandObject.CommandReturnValues.Find(n => n.sName.Equals(CommandRequest_Value.n, sc));
             if (CommandReturnValue == null)
             {

--- a/RSMPGS2/RSMPGS2.cs
+++ b/RSMPGS2/RSMPGS2.cs
@@ -58,6 +58,7 @@ using System.Security.Authentication;
 //                           / Replace "SUL" with "SXL" #85
 //                           / Reset uRt interval when the value changes on RSMPGS 3.2.2 #86
 //                           / Fix support for floating point UpdateRates #88
+//                           / All arguments needs to be present #89
 //
 //
 // ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
All command arguments (except optional ones) needs to be present or else it results in a MessageNotAcknowledged according to RSMP 3.2.2.
Marking command arguments as optional is only possible with the SXL in YAML format