### PR TITLE
Added a warning message if no 'sites' in YAML loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ LogFiles
 bin
 obj
 .vs
+/Settings/ProcessImage.dat

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -266,6 +266,7 @@ namespace nsRSMPGS
 
       if (YAML.YAMLMappings.TryGetValue("sites", out YAMLSites) == false)
       {
+        RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Could not find 'sites' section !");
         return 0;
       }
 
@@ -582,7 +583,7 @@ namespace nsRSMPGS
 
       }
 
-      RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Info, "Loaded {0} objects, {1} alarms, {2} commands, {3} status and {4} agg.status from SXL (YAML) file '{5}'",
+      RSMPGS.SysLog.SysLog( (iLoadedObjects==0) ? cSysLogAndDebug.Severity.Warning : cSysLogAndDebug.Severity.Info, "Loaded {0} objects, {1} alarms, {2} commands, {3} status and {4} agg.status from SXL (YAML) file '{5}'",
       iLoadedObjects, iLoadedAlarms, iLoadedCommands, iLoadedStatus, iLoadedAggregatedStatus, sFileName);
 
       return iReadFiles;


### PR DESCRIPTION
Added a warning message if no 'sites' section found in YAML loaded (useful if loading default YAML SXL generated, by mistake) + modified severity message (warning instead of info) if no objet for sites.
