### PR TITLE
Fix older SXL's included in installation package

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -66,6 +66,9 @@ jobs:
           # Remove any trailing _list because it is only used for comma
           # separated values during schema validation
           sed -i 's/_list$//g' $SXL
+          sed -i 's/_list$//g' $SXL_1_1
+          sed -i 's/_list$//g' $SXL_1_0_15
+          sed -i 's/_list$//g' $SXL_1_0_7
 
       - name: Create XLSX file
         run: |


### PR DESCRIPTION
Remove trailing "_list" in data types in older SXL's.

We pull the SXL from the rsmp_schema repo. The "_list" prefix to data types is used during schema validation (since they're comma separated), but the simulator uses it's own validation.