### PR TITLE
Add ability to edit ExternalAlarmCodeId

### DIFF
--- a/RSMPGS1/RSMPGS1_Main/RSMPGS1_Alarms.cs
+++ b/RSMPGS1/RSMPGS1_Main/RSMPGS1_Alarms.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Windows.Forms;
 using System.IO;
 using System.Diagnostics.Eventing.Reader;
+using RSMP_Messages;
+using System.Reflection;
 
 namespace nsRSMPGS
 {
@@ -297,6 +299,22 @@ namespace nsRSMPGS
 
       try
       {
+        if(iSelectedColumn == 4) // ExternalAlarmCodeId
+        {
+          cAlarmObject AlarmObject = (cAlarmObject)lvItem.Tag;
+          string sValue = lvHitTest.SubItem.Text;
+          List<Dictionary<string, string>> array = new List<Dictionary<string, string>>();
+          cValueTypeObject sExternalAlarmCodeId_type = new cValueTypeObject(null, null, "string", null, 0, 0, null, null);
+          cValue cExternalAlarmCodeId = new cValue(sExternalAlarmCodeId_type, true);
+          cExternalAlarmCodeId.SetValue(AlarmObject.sExternalAlarmCodeId);
+
+          if (cFormsHelper.InputStatusBoxValueType("Enter new value", ref sValue, ref array, cExternalAlarmCodeId, "NULL", true, false) == DialogResult.OK)
+          {
+            AlarmObject.sExternalAlarmCodeId = sValue;
+            lvHitTest.SubItem.Text = sValue;
+          }
+        }
+
         // Tag is ex Value_2
         if ((listview.Columns[iSelectedColumn].Tag != null) && (listview.Columns[iSelectedColumn].Tag.ToString().StartsWith("Value", StringComparison.OrdinalIgnoreCase)))
         {

--- a/RSMPGS1/RSMPGS1_Main/RSMPGS1_Alarms.cs
+++ b/RSMPGS1/RSMPGS1_Main/RSMPGS1_Alarms.cs
@@ -308,7 +308,7 @@ namespace nsRSMPGS
           cValue cExternalAlarmCodeId = new cValue(sExternalAlarmCodeId_type, true);
           cExternalAlarmCodeId.SetValue(AlarmObject.sExternalAlarmCodeId);
 
-          if (cFormsHelper.InputStatusBoxValueType("Enter new value", ref sValue, ref array, cExternalAlarmCodeId, "NULL", true, false) == DialogResult.OK)
+          if (cFormsHelper.InputStatusBoxValueType("Enter new value", ref sValue, ref array, cExternalAlarmCodeId, "Manufacturer specific alarm code and alarm description", true, false) == DialogResult.OK)
           {
             AlarmObject.sExternalAlarmCodeId = sValue;
             lvHitTest.SubItem.Text = sValue;

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -287,6 +287,9 @@ namespace nsRSMPGS
         {
           AlarmObject.AlarmCount = 0;
         }
+        
+        // Update the column "External Alarm Code Id" based on xACId
+        AlarmObject.sExternalAlarmCodeId = AlarmHeader.xACId;
 
         // Don't update the alarm unless the timestamp is equal or newer
         if(DateTime.Compare(AlarmObject.sTimestamp, DateTime.Parse(AlarmHeader.aTs)) <= 0)


### PR DESCRIPTION
ExternalAlarmCodeId is defined in the SXL, but it would be useful to temporarily change it in the GUI.

- [x] RSMPGS1 should not show "NULL" in the input box
- [x] RSMPGS2 should show the value of xACId in ExternalAlarmCodeId column