### PR TITLE
Use strings for the state bits in aggregated status in RSMP 3.1.1 and RSMP 3.1.2

### DIFF
--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace RSMP_Messages
 {
@@ -84,6 +85,24 @@ namespace RSMP_Messages
     public string fS; // functionalState
 
     public bool[] se; // StatusBits
+  }
+
+  // Use string for status bits in RSMP 3.1.1 and RSMP 3.1.2
+  public class AggregatedStatus3_1_2
+  {
+    public string mType;
+    public string type;
+    public string mId;
+
+    public string ntsOId; // ntsObjectId
+    public string xNId; // externalNtsId
+    public string cId; // componentId
+
+    public string aSTS; // AggregatedTimeStamp
+    public string fP; // functionalPosition
+    public string fS; // functionalState
+
+    public List<string> se; // StatusBits
   }
 
   public class AggregatedStatusRequest

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -223,14 +223,14 @@ namespace nsRSMPGS
     }
 
 
-    public void CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject)
+    public RSMP_Messages.AggregatedStatus CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject)
     {
       string sSendBuffer;
 
-      CreateAndSendAggregatedStatusMessage(RoadSideObject, false, out sSendBuffer);
+      return CreateAndSendAggregatedStatusMessage(RoadSideObject, false, out sSendBuffer);
     }
 
-    public void CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject, bool bCreateMessageOnly, out string sSendBuffer)
+    public RSMP_Messages.AggregatedStatus CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject, bool bCreateMessageOnly, out string sSendBuffer)
     {
 
       sSendBuffer = "";
@@ -265,7 +265,7 @@ namespace nsRSMPGS
 
       if (bCreateMessageOnly)
       {
-        return;
+        return AggregatedStatusMessage;
       }
 
       if (RSMPGS.JSon.SendJSonPacket(AggregatedStatusMessage.type, AggregatedStatusMessage.mId, sSendBuffer, true))
@@ -285,6 +285,9 @@ namespace nsRSMPGS
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Buffered aggregated status message, ntsOId: " + AggregatedStatusMessage.ntsOId + ", Type: " + AggregatedStatusMessage.type + ", MsgId: " + AggregatedStatusMessage.mId);
         }
       }
+
+      return AggregatedStatusMessage;
+
     }
 
     private bool DecodeAndParseAggregatedStatusRequestMessage(RSMP_Messages.Header packetHeader, string sJSon, bool bUseStrictProtocolAnalysis, bool bUseCaseSensitiveIds, ref bool bHasSentAckOrNack, ref string sError)

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -223,14 +223,14 @@ namespace nsRSMPGS
     }
 
 
-    public RSMP_Messages.AggregatedStatus CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject)
+    public void CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject)
     {
       string sSendBuffer;
 
-      return CreateAndSendAggregatedStatusMessage(RoadSideObject, false, out sSendBuffer);
+      CreateAndSendAggregatedStatusMessage(RoadSideObject, false, out sSendBuffer);
     }
 
-    public RSMP_Messages.AggregatedStatus CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject, bool bCreateMessageOnly, out string sSendBuffer)
+    public void CreateAndSendAggregatedStatusMessage(cRoadSideObject RoadSideObject, bool bCreateMessageOnly, out string sSendBuffer)
     {
 
       sSendBuffer = "";
@@ -265,7 +265,7 @@ namespace nsRSMPGS
 
       if (bCreateMessageOnly)
       {
-        return AggregatedStatusMessage;
+        return;
       }
 
       if (RSMPGS.JSon.SendJSonPacket(AggregatedStatusMessage.type, AggregatedStatusMessage.mId, sSendBuffer, true))
@@ -285,9 +285,6 @@ namespace nsRSMPGS
           RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Buffered aggregated status message, ntsOId: " + AggregatedStatusMessage.ntsOId + ", Type: " + AggregatedStatusMessage.type + ", MsgId: " + AggregatedStatusMessage.mId);
         }
       }
-
-      return AggregatedStatusMessage;
-
     }
 
     private bool DecodeAndParseAggregatedStatusRequestMessage(RSMP_Messages.Header packetHeader, string sJSon, bool bUseStrictProtocolAnalysis, bool bUseCaseSensitiveIds, ref bool bHasSentAckOrNack, ref string sError)

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -261,7 +261,36 @@ namespace nsRSMPGS
         AggregatedStatusMessage.se[iIndex] = RoadSideObject.bBitStatus[iIndex];
       }
 
-      sSendBuffer = JSonSerializer.SerializeObject(AggregatedStatusMessage);
+      // RSMP 3.1.1 and RSMP 3.1.2 used strings for status bits in aggregated status
+      if (NegotiatedRSMPVersion == RSMPVersion.RSMP_3_1_1 || NegotiatedRSMPVersion == RSMPVersion.RSMP_3_1_2)
+      {
+        RSMP_Messages.AggregatedStatus3_1_2 AggregatedStatusMessage3_1_2 = new RSMP_Messages.AggregatedStatus3_1_2();
+        AggregatedStatusMessage3_1_2.mType = AggregatedStatusMessage.mType;
+        AggregatedStatusMessage3_1_2.type = AggregatedStatusMessage.type;
+        AggregatedStatusMessage3_1_2.mId = AggregatedStatusMessage.mId;
+        AggregatedStatusMessage3_1_2.ntsOId = AggregatedStatusMessage.ntsOId;
+        AggregatedStatusMessage3_1_2.xNId = AggregatedStatusMessage.xNId;
+        AggregatedStatusMessage3_1_2.cId = AggregatedStatusMessage.cId;
+        AggregatedStatusMessage3_1_2.aSTS = AggregatedStatusMessage.aSTS;
+
+        AggregatedStatusMessage3_1_2.fP = AggregatedStatusMessage.fP;
+        AggregatedStatusMessage3_1_2.fS = AggregatedStatusMessage.fS;
+
+        AggregatedStatusMessage3_1_2.se = new List<string>();
+        foreach (bool state in AggregatedStatusMessage.se)
+        {
+          if (state)
+            AggregatedStatusMessage3_1_2.se.Add("True");
+          else
+            AggregatedStatusMessage3_1_2.se.Add("False");
+        }
+
+        sSendBuffer = JSonSerializer.SerializeObject(AggregatedStatusMessage3_1_2);
+      }
+      else
+      { 
+        sSendBuffer = JSonSerializer.SerializeObject(AggregatedStatusMessage);
+      }
 
       if (bCreateMessageOnly)
       {

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -802,15 +802,15 @@ namespace nsRSMPGS
     }
 
 
-    public RSMP_Messages.StatusUpdate CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS)
+    public void CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS)
     {
       string sSendBuffer;
 
-      return CreateAndSendStatusUpdateMessage(RoadSideObject, sS, false, out sSendBuffer);
+      CreateAndSendStatusUpdateMessage(RoadSideObject, sS, false, out sSendBuffer);
     }
 
 
-    public RSMP_Messages.StatusUpdate CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS, bool bCreateMessageOnly, out string sSendBuffer)
+    public void CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS, bool bCreateMessageOnly, out string sSendBuffer)
     {
 
       sSendBuffer = "";
@@ -833,7 +833,7 @@ namespace nsRSMPGS
 
       if (bCreateMessageOnly)
       {
-        return StatusUpdateMessage;
+        return;
       }
 
       if (RSMPGS.JSon.SendJSonPacket(StatusUpdateMessage.type, StatusUpdateMessage.mId, sSendBuffer, true))
@@ -854,7 +854,7 @@ namespace nsRSMPGS
         }
       }
 
-      return StatusUpdateMessage;
+      return;
 
     }
 

--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -802,15 +802,15 @@ namespace nsRSMPGS
     }
 
 
-    public void CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS)
+    public RSMP_Messages.StatusUpdate CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS)
     {
       string sSendBuffer;
 
-      CreateAndSendStatusUpdateMessage(RoadSideObject, sS, false, out sSendBuffer);
+      return CreateAndSendStatusUpdateMessage(RoadSideObject, sS, false, out sSendBuffer);
     }
 
 
-    public void CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS, bool bCreateMessageOnly, out string sSendBuffer)
+    public RSMP_Messages.StatusUpdate CreateAndSendStatusUpdateMessage(cRoadSideObject RoadSideObject, List<RSMP_Messages.Status_VTQ> sS, bool bCreateMessageOnly, out string sSendBuffer)
     {
 
       sSendBuffer = "";
@@ -833,7 +833,7 @@ namespace nsRSMPGS
 
       if (bCreateMessageOnly)
       {
-        return;
+        return StatusUpdateMessage;
       }
 
       if (RSMPGS.JSon.SendJSonPacket(StatusUpdateMessage.type, StatusUpdateMessage.mId, sSendBuffer, true))
@@ -854,7 +854,7 @@ namespace nsRSMPGS
         }
       }
 
-      return;
+      return StatusUpdateMessage;
 
     }
 


### PR DESCRIPTION
Issue: https://github.com/rsmp-nordic/rsmp_simulator/issues/103

- [x] Verify that RSMPGS2 validates the state bits correctly depending on RSMP version