### PR TITLE
In debug window menu, new option to decode times or not + renamed some items

### DIFF
--- a/RSMPCommon/RSMPGS_Debug.cs
+++ b/RSMPCommon/RSMPGS_Debug.cs
@@ -342,23 +342,27 @@ namespace nsRSMPGS
           }
         }
         // Make timestamps more readable...
-        // String.Format("{0:yyyy-MM-dd}T{0:HH:mm:ss.fff}", AlarmHeaderAndBody.aTs.ToLocalTime());
-        // "aTs":"\/Date(1320254751484)\/"
-        //int iDatePosition = sRowData.IndexOf("\\/Date(", StringComparison.OrdinalIgnoreCase);
-        int iDatePosition = sRowData.IndexOf("\":\"20", StringComparison.OrdinalIgnoreCase);
-        if (iDatePosition >= 0)
+        // (if wanted!)
+        if (ToolStripMenuItem_DecodedTimes.Checked)
         {
-          try
+          // String.Format("{0:yyyy-MM-dd}T{0:HH:mm:ss.fff}", AlarmHeaderAndBody.aTs.ToLocalTime());
+          // "aTs":"\/Date(1320254751484)\/"
+          //int iDatePosition = sRowData.IndexOf("\\/Date(", StringComparison.OrdinalIgnoreCase);
+          int iDatePosition = sRowData.IndexOf("\":\"20", StringComparison.OrdinalIgnoreCase);
+          if (iDatePosition >= 0)
           {
-            // "aSTS":"2019-02-26T15:36:17.588Z","
-            if (sRowData.Substring(iDatePosition + 13, 1).Equals("T", StringComparison.OrdinalIgnoreCase))
+            try
             {
-              DateTime dtTimeStamp = DateTime.ParseExact(sRowData.Substring(iDatePosition + 3, 24).ToUpper(), @"yyyy-MM-dd\THH:mm:ss.fff\Z", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
-              sRowData += " << debugger decoded UTC: " + String.Format("{0:yyyy-MM-dd} {0:HH:mm:ss.fff}", dtTimeStamp.ToUniversalTime()) + ", local: " + String.Format("{0:yyyy-MM-dd} {0:HH:mm:ss.fff}", dtTimeStamp.ToLocalTime()) + " >>";
+              // "aSTS":"2019-02-26T15:36:17.588Z","
+              if (sRowData.Substring(iDatePosition + 13, 1).Equals("T", StringComparison.OrdinalIgnoreCase))
+              {
+                DateTime dtTimeStamp = DateTime.ParseExact(sRowData.Substring(iDatePosition + 3, 24).ToUpper(), @"yyyy-MM-dd\THH:mm:ss.fff\Z", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                sRowData += " << debugger decoded UTC: " + String.Format("{0:yyyy-MM-dd} {0:HH:mm:ss.fff}", dtTimeStamp.ToUniversalTime()) + ", local: " + String.Format("{0:yyyy-MM-dd} {0:HH:mm:ss.fff}", dtTimeStamp.ToLocalTime()) + " >>";
+              }
             }
-          }
-          catch
-          {
+            catch
+            {
+            }
           }
         }
 

--- a/RSMPCommon/RSMPGS_Debug.designer.cs
+++ b/RSMPCommon/RSMPGS_Debug.designer.cs
@@ -61,6 +61,7 @@
       this.columnHeader_Time = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
       this.columnHeader_Direction = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
       this.columnHeader_Text = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+      this.ToolStripMenuItem_DecodedTimes = new System.Windows.Forms.ToolStripMenuItem();
       this.menuStrip_Debug.SuspendLayout();
       this.SuspendLayout();
       // 
@@ -71,7 +72,7 @@
             this.ToolStripMenuItem_Debug});
       this.menuStrip_Debug.Location = new System.Drawing.Point(0, 0);
       this.menuStrip_Debug.Name = "menuStrip_Debug";
-      this.menuStrip_Debug.Size = new System.Drawing.Size(823, 30);
+      this.menuStrip_Debug.Size = new System.Drawing.Size(823, 28);
       this.menuStrip_Debug.TabIndex = 0;
       this.menuStrip_Debug.Text = "menuStrip1";
       // 
@@ -88,7 +89,7 @@
             this.toolStripMenuItem_Delimiter_3,
             this.ToolStripMenuItem_CloseForm});
       this.ToolStripMenuItem_Debug.Name = "ToolStripMenuItem_Debug";
-      this.ToolStripMenuItem_Debug.Size = new System.Drawing.Size(68, 26);
+      this.ToolStripMenuItem_Debug.Size = new System.Drawing.Size(68, 24);
       this.ToolStripMenuItem_Debug.Text = "&Debug";
       this.ToolStripMenuItem_Debug.DropDownOpening += new System.EventHandler(this.ToolStripMenuItem_Debug_DropDownOpening);
       // 
@@ -96,6 +97,7 @@
       // 
       this.ToolStripMenuItem_PacketTypes.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ToolStripMenuItem_PacketTypes_Raw,
+            this.ToolStripMenuItem_DecodedTimes,
             this.ToolStripMenuItem_PacketTypes_Delimiter_0,
             this.ToolStripMenuItem_PacketTypes_All,
             this.ToolStripMenuItem_PacketTypes_Delimiter_1,
@@ -111,7 +113,7 @@
             this.ToolStripMenuItem_PacketTypes_Unknown});
       this.ToolStripMenuItem_PacketTypes.Name = "ToolStripMenuItem_PacketTypes";
       this.ToolStripMenuItem_PacketTypes.Size = new System.Drawing.Size(300, 26);
-      this.ToolStripMenuItem_PacketTypes.Text = "Select &what to debug...";
+      this.ToolStripMenuItem_PacketTypes.Text = "Select what to &debug...";
       this.ToolStripMenuItem_PacketTypes.DropDownOpening += new System.EventHandler(this.ToolStripMenuItem_PacketTypes_DropDownOpening);
       // 
       // ToolStripMenuItem_PacketTypes_Raw
@@ -239,7 +241,7 @@
       this.ToolStripMenuItem_ShowLastRow.CheckState = System.Windows.Forms.CheckState.Checked;
       this.ToolStripMenuItem_ShowLastRow.Name = "ToolStripMenuItem_ShowLastRow";
       this.ToolStripMenuItem_ShowLastRow.Size = new System.Drawing.Size(300, 26);
-      this.ToolStripMenuItem_ShowLastRow.Text = "Always show last row";
+      this.ToolStripMenuItem_ShowLastRow.Text = "&Auto-scroll to last line";
       // 
       // toolStripMenuItem_Delimiter_1
       // 
@@ -281,7 +283,7 @@
       // 
       this.ToolStripMenuItem_CloseForm.Name = "ToolStripMenuItem_CloseForm";
       this.ToolStripMenuItem_CloseForm.Size = new System.Drawing.Size(300, 26);
-      this.ToolStripMenuItem_CloseForm.Text = "&Close debug form";
+      this.ToolStripMenuItem_CloseForm.Text = "Close debug &window";
       this.ToolStripMenuItem_CloseForm.Click += new System.EventHandler(this.ToolStripMenuItem_CloseForm_Click);
       // 
       // saveFileDialog_Debug
@@ -305,10 +307,10 @@
       this.listView_Debug.Dock = System.Windows.Forms.DockStyle.Fill;
       this.listView_Debug.FullRowSelect = true;
       this.listView_Debug.HideSelection = false;
-      this.listView_Debug.Location = new System.Drawing.Point(0, 30);
+      this.listView_Debug.Location = new System.Drawing.Point(0, 28);
       this.listView_Debug.Margin = new System.Windows.Forms.Padding(4);
       this.listView_Debug.Name = "listView_Debug";
-      this.listView_Debug.Size = new System.Drawing.Size(823, 568);
+      this.listView_Debug.Size = new System.Drawing.Size(823, 570);
       this.listView_Debug.TabIndex = 1;
       this.listView_Debug.UseCompatibleStateImageBehavior = false;
       this.listView_Debug.View = System.Windows.Forms.View.Details;
@@ -327,6 +329,15 @@
       // 
       this.columnHeader_Text.Text = "Data";
       this.columnHeader_Text.Width = 447;
+      // 
+      // ToolStripMenuItem_DecodedTimes
+      // 
+      this.ToolStripMenuItem_DecodedTimes.Checked = true;
+      this.ToolStripMenuItem_DecodedTimes.CheckOnClick = true;
+      this.ToolStripMenuItem_DecodedTimes.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.ToolStripMenuItem_DecodedTimes.Name = "ToolStripMenuItem_DecodedTimes";
+      this.ToolStripMenuItem_DecodedTimes.Size = new System.Drawing.Size(284, 26);
+      this.ToolStripMenuItem_DecodedTimes.Text = "Show decoded &times";
       // 
       // RSMPGS_Debug
       // 
@@ -384,5 +395,6 @@
     private System.Windows.Forms.ToolStripSeparator ToolStripMenuItem_PacketTypes_Delimiter_3;
     public System.Windows.Forms.ToolStripMenuItem ToolStripMenuItem_PacketTypes_Version;
     public System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_SaveContinousToFile;
+    public System.Windows.Forms.ToolStripMenuItem ToolStripMenuItem_DecodedTimes;
   }
 }


### PR DESCRIPTION
In debug window menu, added a new option to be able to select if we want to decode times or not (usefull for RSMP messages copies of examples in documentation) + renamed some items and keys shortcuts (to be more understandable => especially after a colleague failed to notice that it was possible to disable automatic scrolling!)).