### PR TITLE
Ctrl+c to copy selection in debug window + option copy data only

### DIFF
--- a/RSMPCommon/RSMPGS_Debug.cs
+++ b/RSMPCommon/RSMPGS_Debug.cs
@@ -415,15 +415,23 @@ namespace nsRSMPGS
       toolStripMenuItem_SaveContinousToFile.Checked = swDebugFile != null;
     }
 
-    private void toolStripMenuItem_CopyToClipboard_Click(object sender, EventArgs e)
+    private string GetCurrentLinesSelected()
     {
       string sDebugData = "";
       foreach (ListViewItem lvItem in listView_Debug.SelectedItems)
       {
         string sDebugLine = "";
-        foreach (ListViewItem.ListViewSubItem lvSubItem in lvItem.SubItems)
+        if (!toolStripMenuItem_CopyOnlyTextToClipboard.Checked)
         {
-          sDebugLine += lvSubItem.Text;
+          foreach (ListViewItem.ListViewSubItem lvSubItem in lvItem.SubItems)
+          {
+            sDebugLine += lvSubItem.Text;
+            sDebugLine += "\t";
+          }
+        }
+        else
+        {
+          sDebugLine = lvItem.SubItems[2].Text;
           sDebugLine += "\t";
         }
         if (sDebugData.Length > 0)
@@ -432,8 +440,34 @@ namespace nsRSMPGS
         }
         sDebugData += sDebugLine.Substring(0, sDebugLine.Length - 1); ;
       }
+      return sDebugData;
+    }
+
+    private void toolStripMenuItem_CopyToClipboard_Click(object sender, EventArgs e)
+    {
       Clipboard.Clear();
-      Clipboard.SetText(sDebugData);
+      string sDebugData = GetCurrentLinesSelected();
+      if (sDebugData != "")
+        Clipboard.SetText(sDebugData);
+    }
+
+    // Keys Ctrl+C also to copy current selection.
+    private void RSMPGS_Debug_KeyDown(object sender, KeyEventArgs e)
+    {
+      if (e.Modifiers == Keys.Control && e.KeyCode == Keys.C)
+      {
+        if (listView_Debug.SelectedItems.Count > 0)
+        {
+          Clipboard.Clear();
+          string sDebugData = GetCurrentLinesSelected();
+          if (sDebugData != "")
+            Clipboard.SetText(sDebugData);
+        }
+        else
+        {
+          MessageBox.Show("No line currently selected !");
+        }
+      }
     }
 
     private void toolStripMenuItem_Clear_Click(object sender, EventArgs e)
@@ -573,6 +607,11 @@ namespace nsRSMPGS
 
     }
 
+    // auto-resize Data column according to window width
+    private void RSMPGS_Debug_SizeChanged(object sender, EventArgs e)
+    {
+      this.columnHeader_Text.Width = this.Width-this.columnHeader_Direction.Width-this.columnHeader_Time.Width-40;
+    }
   }
 
 }

--- a/RSMPCommon/RSMPGS_Debug.cs
+++ b/RSMPCommon/RSMPGS_Debug.cs
@@ -417,30 +417,31 @@ namespace nsRSMPGS
 
     private string GetCurrentLinesSelected()
     {
-      string sDebugData = "";
+      string sDebugAllLines = "";
       foreach (ListViewItem lvItem in listView_Debug.SelectedItems)
       {
         string sDebugLine = "";
         if (!toolStripMenuItem_CopyOnlyTextToClipboard.Checked)
         {
+          bool bFirstCol = true;
           foreach (ListViewItem.ListViewSubItem lvSubItem in lvItem.SubItems)
           {
+            if (!bFirstCol)
+              sDebugLine += "\t";
+            else
+              bFirstCol = false;
             sDebugLine += lvSubItem.Text;
-            sDebugLine += "\t";
           }
         }
-        else
+        else if (lvItem.SubItems.Count>=3)
         {
           sDebugLine = lvItem.SubItems[2].Text;
-          sDebugLine += "\t";
         }
-        if (sDebugData.Length > 0)
-        {
-          sDebugData += "\r\n";
-        }
-        sDebugData += sDebugLine.Substring(0, sDebugLine.Length - 1); ;
+        if (sDebugAllLines.Length > 0)
+          sDebugAllLines += "\r\n";
+        sDebugAllLines += sDebugLine;
       }
-      return sDebugData;
+      return sDebugAllLines;
     }
 
     private void toolStripMenuItem_CopyToClipboard_Click(object sender, EventArgs e)

--- a/RSMPCommon/RSMPGS_Debug.designer.cs
+++ b/RSMPCommon/RSMPGS_Debug.designer.cs
@@ -61,6 +61,7 @@
       this.columnHeader_Time = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
       this.columnHeader_Direction = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
       this.columnHeader_Text = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+      this.toolStripMenuItem_CopyOnlyTextToClipboard = new System.Windows.Forms.ToolStripMenuItem();
       this.menuStrip_Debug.SuspendLayout();
       this.SuspendLayout();
       // 
@@ -71,7 +72,7 @@
             this.ToolStripMenuItem_Debug});
       this.menuStrip_Debug.Location = new System.Drawing.Point(0, 0);
       this.menuStrip_Debug.Name = "menuStrip_Debug";
-      this.menuStrip_Debug.Size = new System.Drawing.Size(823, 30);
+      this.menuStrip_Debug.Size = new System.Drawing.Size(823, 28);
       this.menuStrip_Debug.TabIndex = 0;
       this.menuStrip_Debug.Text = "menuStrip1";
       // 
@@ -81,6 +82,7 @@
             this.ToolStripMenuItem_PacketTypes,
             this.ToolStripMenuItem_ShowLastRow,
             this.toolStripMenuItem_Delimiter_1,
+            this.toolStripMenuItem_CopyOnlyTextToClipboard,
             this.toolStripMenuItem_CopyToClipboard,
             this.toolStripMenuItem_Clear,
             this.toolStripMenuItem_Delimiter_2,
@@ -88,7 +90,7 @@
             this.toolStripMenuItem_Delimiter_3,
             this.ToolStripMenuItem_CloseForm});
       this.ToolStripMenuItem_Debug.Name = "ToolStripMenuItem_Debug";
-      this.ToolStripMenuItem_Debug.Size = new System.Drawing.Size(68, 26);
+      this.ToolStripMenuItem_Debug.Size = new System.Drawing.Size(68, 24);
       this.ToolStripMenuItem_Debug.Text = "&Debug";
       this.ToolStripMenuItem_Debug.DropDownOpening += new System.EventHandler(this.ToolStripMenuItem_Debug_DropDownOpening);
       // 
@@ -305,10 +307,10 @@
       this.listView_Debug.Dock = System.Windows.Forms.DockStyle.Fill;
       this.listView_Debug.FullRowSelect = true;
       this.listView_Debug.HideSelection = false;
-      this.listView_Debug.Location = new System.Drawing.Point(0, 30);
+      this.listView_Debug.Location = new System.Drawing.Point(0, 28);
       this.listView_Debug.Margin = new System.Windows.Forms.Padding(4);
       this.listView_Debug.Name = "listView_Debug";
-      this.listView_Debug.Size = new System.Drawing.Size(823, 568);
+      this.listView_Debug.Size = new System.Drawing.Size(823, 570);
       this.listView_Debug.TabIndex = 1;
       this.listView_Debug.UseCompatibleStateImageBehavior = false;
       this.listView_Debug.View = System.Windows.Forms.View.Details;
@@ -326,7 +328,14 @@
       // columnHeader_Text
       // 
       this.columnHeader_Text.Text = "Data";
-      this.columnHeader_Text.Width = 447;
+      this.columnHeader_Text.Width = 592;
+      // 
+      // toolStripMenuItem_CopyOnlyTextToClipboard
+      // 
+      this.toolStripMenuItem_CopyOnlyTextToClipboard.CheckOnClick = true;
+      this.toolStripMenuItem_CopyOnlyTextToClipboard.Name = "toolStripMenuItem_CopyOnlyTextToClipboard";
+      this.toolStripMenuItem_CopyOnlyTextToClipboard.Size = new System.Drawing.Size(300, 26);
+      this.toolStripMenuItem_CopyOnlyTextToClipboard.Text = "Copy only Data to Clipboard";
       // 
       // RSMPGS_Debug
       // 
@@ -336,6 +345,7 @@
       this.Controls.Add(this.listView_Debug);
       this.Controls.Add(this.menuStrip_Debug);
       this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+      this.KeyPreview = true;
       this.MainMenuStrip = this.menuStrip_Debug;
       this.Margin = new System.Windows.Forms.Padding(4);
       this.Name = "RSMPGS_Debug";
@@ -344,6 +354,8 @@
       this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.RSMPGS_Debug_FormClosing);
       this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.RSMPGS_Debug_FormClosed);
       this.Load += new System.EventHandler(this.RSMPGS_Debug_Load);
+      this.SizeChanged += new System.EventHandler(this.RSMPGS_Debug_SizeChanged);
+      this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RSMPGS_Debug_KeyDown);
       this.menuStrip_Debug.ResumeLayout(false);
       this.menuStrip_Debug.PerformLayout();
       this.ResumeLayout(false);
@@ -384,5 +396,6 @@
     private System.Windows.Forms.ToolStripSeparator ToolStripMenuItem_PacketTypes_Delimiter_3;
     public System.Windows.Forms.ToolStripMenuItem ToolStripMenuItem_PacketTypes_Version;
     public System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_SaveContinousToFile;
+    private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem_CopyOnlyTextToClipboard;
   }
 }


### PR DESCRIPTION
Added fastest shortcut ctrl+c to copy selection in debug to clipboard + option to copy only Data colum + directly auto-resize Data column according to window width.