### PR TITLE
Handle undefined and unknown quality

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1357,18 +1357,18 @@ namespace nsRSMPGS
       return "[" + objectsString + "]";
     }
 
-    public bool ValidateTypeAndRange(string sType, string sValue, Dictionary<string, string> sEnums)
+    public bool ValidateTypeAndRange(string sType, object oValue, Dictionary<string, string> sEnums)
     {
-      return ValidateTypeAndRange(sType, sValue, sEnums, 0, 0);
+      return ValidateTypeAndRange(sType, oValue, sEnums, 0, 0);
     }
 
-    public bool ValidateTypeAndRange(string sType, string sValue, Dictionary<string, string> sEnums, double dMin, double dMax)
+    public bool ValidateTypeAndRange(string sType, object oValue, Dictionary<string, string> sEnums, double dMin, double dMax)
     {
       bool bUseCaseSensitiveValue = cHelper.IsSettingChecked("UseCaseSensitiveValue");
       var comparisonType = StringComparison.Ordinal;
       if (!bUseCaseSensitiveValue) { comparisonType = StringComparison.OrdinalIgnoreCase; }
 
-      if (sValue == null)
+      if (oValue == null)
       {
         return false;
       }
@@ -1386,7 +1386,7 @@ namespace nsRSMPGS
         case "integer":
           try
           {
-            Int32 iValue = Int32.Parse(sValue);
+            Int32 iValue = Int32.Parse(oValue.ToString());
             bValueIsValid = true;
           }
           catch { }
@@ -1395,7 +1395,7 @@ namespace nsRSMPGS
         case "long":
           try
           {
-            Int32 iValue = Int32.Parse(sValue);
+            Int32 iValue = Int32.Parse(oValue.ToString());
             bValueIsValid = true;
           }
           catch { }
@@ -1405,7 +1405,7 @@ namespace nsRSMPGS
         case "real":
           try
           {
-            Double dValue = Double.Parse(sValue);
+            Double dValue = Double.Parse(oValue.ToString());
             bValueIsValid = true;
           }
           catch { }
@@ -1415,10 +1415,10 @@ namespace nsRSMPGS
           // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
           // preserve backwards compability we need to treat this as case
           // insensitive for now
-          bValueIsValid = sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("1", StringComparison.OrdinalIgnoreCase);
+          bValueIsValid = oValue.ToString().Equals("true", StringComparison.OrdinalIgnoreCase) ||
+            oValue.ToString().Equals("false", StringComparison.OrdinalIgnoreCase) ||
+            oValue.ToString().Equals("0", StringComparison.OrdinalIgnoreCase) ||
+            oValue.ToString().Equals("1", StringComparison.OrdinalIgnoreCase);
           break;
 
         case "base64":
@@ -1426,7 +1426,7 @@ namespace nsRSMPGS
           {
             Encoding encoding;
             encoding = Encoding.GetEncoding("IBM437");
-            byte[] Base64Bytes = encoding.GetBytes(sValue);
+            byte[] Base64Bytes = encoding.GetBytes(oValue.ToString());
             char[] Base64Chars = encoding.GetChars(Base64Bytes);
             byte[] Base8Bytes = System.Convert.FromBase64CharArray(Base64Chars, 0, Base64Chars.GetLength(0));
             bValueIsValid = true;
@@ -1440,7 +1440,7 @@ namespace nsRSMPGS
           {
             try
             {
-              UInt32 iValue = UInt32.Parse(sValue);
+              UInt32 iValue = UInt32.Parse(oValue.ToString());
               bValueIsValid = true;
             }
             catch { }
@@ -1470,7 +1470,7 @@ namespace nsRSMPGS
 
             try
             {
-              Double dValue = Double.Parse(sValue);
+              Double dValue = Double.Parse(oValue.ToString());
               bValueIsValid = dValue <= dMax && dValue >= dMin;
 
               if (sEnums != null && sEnums.Count > 0)
@@ -1478,7 +1478,7 @@ namespace nsRSMPGS
                 bValueIsValid = false;
                 foreach (string sEnum in sEnums.Keys)
                 {
-                  if (sValue.Equals(sEnum, comparisonType))
+                  if (oValue.ToString().Equals(sEnum, comparisonType))
                   {
                     bValueIsValid = true;
                   }
@@ -1497,7 +1497,7 @@ namespace nsRSMPGS
                 bValueIsValid = false;
                 foreach (string sEnum in sEnums.Keys)
                 {
-                  if (sValue.Equals(sEnum, comparisonType))
+                  if (oValue.ToString().Equals(sEnum, comparisonType))
                   {
                     bValueIsValid = true;
                   }

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -524,6 +524,7 @@ namespace nsRSMPGS
     public enum eQuality
     {
       unknown,
+      undefined,
       recent,
       old
     }

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -519,7 +519,14 @@ namespace nsRSMPGS
           }
           else
           {
-            StatusReturnValue.Value.SetValue(Reply.s.ToString());
+            if(Reply.s == null)
+            {
+                StatusReturnValue.Value.SetValue("(null)");
+            }
+            else
+            {
+                StatusReturnValue.Value.SetValue(Reply.s.ToString());
+            }
           }
 
           if (StatusReturnValue.Value.ValueTypeObject.ValueType.ToString() == "_array")

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -559,25 +559,25 @@ namespace nsRSMPGS
           if(StatusReturnValue.sQuality == cValue.eQuality.unknown.ToString())
           {
             // if quality is unknown, skip validation of string
-            sError = "Status unimplemeted? Quality is unknown.";
+            sError = "Failed to handle Status message. Quality: unknown";
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, sError);
-            return true; // Return messageAck
+            return true; // Return MessageAck
           }
 
           if (StatusReturnValue.sQuality == cValue.eQuality.undefined.ToString())
           {
             // Check if rsmp version is supported, if not error
-            if (NegotiatedRSMPVersion > RSMPVersion.RSMP_3_1_3)
+            if (NegotiatedRSMPVersion >= RSMPVersion.RSMP_3_1_3)
             {
-                sError = "Component unknown? Quality is undefined.";
+                sError = "Failed to handle Status message. Quality: undefined";
                 RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, sError);
-                return true; // Return messageAck
+                return true; // Return MessageAck
             }
             else
             {
-                sError = "Component unknown? Quality is undefined not added until RSMP 3.1.3.";
+                sError = "Failed to handle Status message. Quality: undefined. (Not added until RSMP 3.1.3)";
                 RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
-                return false;
+                return false; // Return MessageNotAck
             }
           }
 

--- a/RSMPGS2/RSMPGS2_JSon.cs
+++ b/RSMPGS2/RSMPGS2_JSon.cs
@@ -556,7 +556,32 @@ namespace nsRSMPGS
             return false;
           }
 
-          if (!ValidateTypeAndRange(StatusReturnValue.Value.GetValueType(), Reply.s.ToString(), StatusReturnValue.Value.GetSelectableValues(), StatusReturnValue.Value.GetValueMin(), StatusReturnValue.Value.GetValueMax()))
+          if(StatusReturnValue.sQuality == cValue.eQuality.unknown.ToString())
+          {
+            // if quality is unknown, skip validation of string
+            sError = "Status unimplemeted? Quality is unknown.";
+            RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, sError);
+            return true; // Return messageAck
+          }
+
+          if (StatusReturnValue.sQuality == cValue.eQuality.undefined.ToString())
+          {
+            // Check if rsmp version is supported, if not error
+            if (NegotiatedRSMPVersion > RSMPVersion.RSMP_3_1_3)
+            {
+                sError = "Component unknown? Quality is undefined.";
+                RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, sError);
+                return true; // Return messageAck
+            }
+            else
+            {
+                sError = "Component unknown? Quality is undefined not added until RSMP 3.1.3.";
+                RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, sError);
+                return false;
+            }
+          }
+
+          if (!ValidateTypeAndRange(StatusReturnValue.Value.GetValueType(), Reply.s, StatusReturnValue.Value.GetSelectableValues(), StatusReturnValue.Value.GetValueMin(), StatusReturnValue.Value.GetValueMax()))
           {
             string sStatusValue;
             if (Reply.s == null)


### PR DESCRIPTION
RSMPGS2 does not handle q='undefined' or q='unknown' correctly, resulting in an error. This PR implements proper handling of `undefined` and `unknown` quality.

Original issue: https://github.com/rsmp-nordic/rsmp_simulator/issues/120