### PR TITLE
Don't process partial commands

### DIFF
--- a/RSMPGS1/RSMPGS1_JSon.cs
+++ b/RSMPGS1/RSMPGS1_JSon.cs
@@ -492,7 +492,6 @@ namespace nsRSMPGS
 
         // Check for unknown command code id (cCI) and unknown name (n) in arguments
         // Only MessageNotAck should be sent in such case
-        // Scan through each value to set
         cRoadSideObject RoadSideObject = cHelper.FindRoadSideObject(CommandRequest.ntsOId, CommandRequest.cId, bUseStrictProtocolAnalysis);
         foreach (RSMP_Messages.CommandRequest_Value CommandRequest_Value in CommandRequest.arg)
         {
@@ -521,6 +520,33 @@ namespace nsRSMPGS
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
 
             // MessageNotAck
+            if (!bHasSentAckOrNack)
+            {
+              bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
+            }
+            return false;
+          }
+
+          if (!CommandReturnValue.sCommand.Equals(CommandRequest_Value.cO, sc))
+          {
+            // Cannot find command (cO)
+            sError = "Got Command, failed to find command (NTSObjectId: " + CommandRequest.ntsOId + ", ComponentId: " + CommandRequest.cId + ", CommandCodeId: " + CommandRequest_Value.cCI + ", Name: " + CommandRequest_Value.n + ", Command: " + CommandRequest_Value.cO + ", Value: " + CommandRequest_Value.v + ")";
+            RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
+
+            // MessageNotAck
+            if (!bHasSentAckOrNack)
+            {
+              bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
+            }
+            return false;
+          }
+
+          if (!ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), CommandRequest_Value.v, CommandReturnValue.Value.GetSelectableValues(),
+            CommandReturnValue.Value.GetValueMin(), CommandReturnValue.Value.GetValueMax()))
+          {
+            // MessageNotAck
+            sError = "Value and/or type is out of range or invalid for this RSMP protocol version, type: " + CommandReturnValue.Value.GetValueType() + ", value: " + ((CommandRequest_Value.v.Length < 10) ? CommandRequest_Value.v : CommandRequest_Value.v.Substring(0, 9) + "...");
+            RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
             if (!bHasSentAckOrNack)
             {
               bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
@@ -598,38 +624,6 @@ namespace nsRSMPGS
             }
 
             cCommandReturnValue CommandReturnValue = CommandObject.CommandReturnValues.Find(n => n.sName.Equals(CommandRequest_Value.n, sc));
-
-            if (!CommandReturnValue.sCommand.Equals(CommandRequest_Value.cO, sc))
-            {
-              // Cannot find command (cO)
-              sError = "Got Command, failed to find command (NTSObjectId: " + CommandRequest.ntsOId + ", ComponentId: " + CommandRequest.cId + ", CommandCodeId: " + CommandRequest_Value.cCI + ", Name: " + CommandRequest_Value.n + ", Command: " + CommandRequest_Value.cO + ", Value: " + CommandRequest_Value.v + ")";
-              RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
-
-              // MessageNotAck
-              if (!bHasSentAckOrNack)
-              {
-                bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
-              }
-              return false;
-            }
-
-            if (!ValidateTypeAndRange(CommandReturnValue.Value.GetValueType(), CommandRequest_Value.v, CommandReturnValue.Value.GetSelectableValues(),
-              CommandReturnValue.Value.GetValueMin(), CommandReturnValue.Value.GetValueMax()))
-            {
-              // Value fails validation
-              rv.v = null;
-              rv.age = "unknown";
-
-              // MessageNotAck
-              sError = "Value and/or type is out of range or invalid for this RSMP protocol version, type: " + CommandReturnValue.Value.GetValueType() + ", value: " + ((CommandRequest_Value.v.Length < 10) ? CommandRequest_Value.v : CommandRequest_Value.v.Substring(0, 9) + "...");
-              RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Error, "{0}", sError);
-              if (!bHasSentAckOrNack)
-              {
-                bHasSentAckOrNack = SendPacketAck(false, packetHeader.mId, sError);
-              }
-              return false;
-            }
-
             if (CommandReturnValue.Value.GetValueType().Equals("base64", StringComparison.OrdinalIgnoreCase))
             {
               if (RSMPGS.MainForm.ToolStripMenuItem_StoreBase64Updates.Checked)


### PR DESCRIPTION
Don't process partial commands if any argument uses incorrect command code id, name (n), command (co) or value

This moves the check for command code id (cId), name (n), command (co) and value validation to the beginning of DecodeAndParseCommandMessage() since no response needs to be constructed and no processing of values should yet start.
