### PR TITLE
Validate legacy type boolean_list_as_string

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1467,6 +1467,11 @@ namespace nsRSMPGS
         if (sType.ToLower() == "integer")
           sType = "integer_list_as_string";
 
+      // Legacy: If RSMP < 3.3.0, boolean needs to be treated as boolean_list_as_string
+      if (NegotiatedRSMPVersion < RSMPVersion.RSMP_3_3_0)
+        if (sType.ToLower() == "boolean")
+          sType = "boolean_list_as_string";
+
       bool bValueIsValid = false;
 
       switch (sType.ToLower())
@@ -1529,6 +1534,24 @@ namespace nsRSMPGS
             oValue.ToString().Equals("false", StringComparison.OrdinalIgnoreCase) ||
             oValue.ToString().Equals("0", StringComparison.OrdinalIgnoreCase) ||
             oValue.ToString().Equals("1", StringComparison.OrdinalIgnoreCase);
+          break;
+
+        case "boolean_list_as_string":
+          // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
+          // preserve backwards compatibility we need to treat this as case
+          // insensitive for now
+
+          bValueIsValid = true;
+          foreach (string cValue in oValue.ToString().Split(','))
+          {
+            if(!(cValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("1", StringComparison.OrdinalIgnoreCase)));
+            {
+              bValueIsValid = false;
+            }
+          }
           break;
 
         case "base64":

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -1547,7 +1547,7 @@ namespace nsRSMPGS
             if(!(cValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
               cValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
               cValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-              cValue.Equals("1", StringComparison.OrdinalIgnoreCase)));
+              cValue.Equals("1", StringComparison.OrdinalIgnoreCase)))
             {
               bValueIsValid = false;
             }

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -887,10 +887,10 @@ namespace nsRSMPGS
             // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
             // preserve backwards compatibility we need to treat this as case
             // insensitive for now
-            if (!(sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-              sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-              sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-              sValue.Equals("1", StringComparison.OrdinalIgnoreCase)))
+            if (!(cValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+              cValue.Equals("1", StringComparison.OrdinalIgnoreCase)))
             {
               return false;
             }

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -686,8 +686,10 @@ namespace nsRSMPGS
         case eValueType._boolean:
           if (sValue.Equals("True", StringComparison.InvariantCultureIgnoreCase))
             this.oValue = true;
-          else
+          else if (sValue.Equals("False", StringComparison.InvariantCultureIgnoreCase))
             this.oValue = false;
+          else
+            this.oValue = sValue == null ? null : sValue.ToString();
           break;
         default:
           this.oValue = sValue == null ? null : sValue.ToString();

--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -881,20 +881,21 @@ namespace nsRSMPGS
 
         case eValueType._boolean:
 
-          // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
-          // preserve backwards compatibility we need to treat this as case
-          // insensitive for now
-          if (sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
-            sValue.Equals("1", StringComparison.OrdinalIgnoreCase))
+          // Handle comma separated lists needed for backwards compatibility.
+          foreach (string cValue in sValue.Split(','))
           {
-            return true;
+            // Boolean is treated as an enum in Excel/CSV, but not in YAML. To
+            // preserve backwards compatibility we need to treat this as case
+            // insensitive for now
+            if (!(sValue.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+              sValue.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+              sValue.Equals("0", StringComparison.OrdinalIgnoreCase) ||
+              sValue.Equals("1", StringComparison.OrdinalIgnoreCase)))
+            {
+              return false;
+            }
           }
-          else
-          {
-            return false;
-          }
+          return true;
 
         case eValueType._integer:
 


### PR DESCRIPTION
Handle comma separated boolean lists needed for backwards compatibility

Older SXL uses "boolean" but they're sometimes comma separated boolean lists. These causes validation failures which makes them impossible to save in process lists, among other problems.

This PR introduces a workaround to make them work anyway.
