### PR TITLE
RSMPGS2: Only send the negotiated RSMP version in the version response

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -716,6 +716,7 @@ namespace nsRSMPGS
 
       cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
+# if _RSMPGS1
       for (iIndex = 1; iIndex < sRSMPVersions.GetLength(0); iIndex++)
       {
         if (setting.GetActualValue((RSMPVersion)iIndex))
@@ -723,7 +724,11 @@ namespace nsRSMPGS
           rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions[iIndex]));
         }
       }
-      
+#else
+      // Only send the highest supported version, which will be the negotiated version
+      rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions.Last()));
+#endif
+
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {
@@ -771,6 +776,7 @@ namespace nsRSMPGS
 
       cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
+# if _RSMPGS1
       for (iIndex = 1; iIndex < sRSMPVersions.GetLength(0); iIndex++)
       {
         if (setting.GetActualValue((RSMPVersion)iIndex))
@@ -778,6 +784,10 @@ namespace nsRSMPGS
           rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions[iIndex]));
         }
       }
+#else
+      // Only send the highest supported version, which will be the negotiated version
+      rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions.Last()));
+#endif
 
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)


### PR DESCRIPTION
Only send the "common" RSMP version as the version response in RSMPGS2. This will be the negotiated version.

This is discussed in https://github.com/rsmp-nordic/rsmp_core/issues/123 and later also part of the PR ~~https://github.com/rsmp-nordic/rsmp_core/pull/261~~ https://github.com/rsmp-nordic/rsmp_core/pull/277

Wait until this change is merged in RSMP Core.