### PR TITLE
RSMP 3.3.0: No "SXL" in version response

### DIFF
--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -875,7 +875,8 @@ namespace nsRSMPGS
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Client RSMP version '{0}' is unknown", Version_RSMP.vers.Trim());
           }
         }
-        bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
+        if(rsVersion != null)
+          bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
 
 #if _RSMPGS1
         if (HighestRSMPVersion == RSMPVersion.RSMP_3_3_0)

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -838,7 +838,7 @@ namespace nsRSMPGS
 
       try
       {
-        RSMP_Messages.rsVersion_From_3_3_0 rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_From_3_3_0>(sJSon);
+        RSMP_Messages.rsVersion_Until_3_3_0 rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_Until_3_3_0>(sJSon);
 
         cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -875,7 +875,7 @@ namespace nsRSMPGS
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Client RSMP version '{0}' is unknown", Version_RSMP.vers.Trim());
           }
         }
-        if(rsVersion != null)
+        if(rsVersion.SXL != null)
           bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
 
 #if _RSMPGS1

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -755,7 +755,7 @@ namespace nsRSMPGS
     public cJSonMessageIdAndTimeStamp CreateAndSendVersionMessage_From_3_3_0()
     {
 
-      RSMP_Messages.rsVersion_From_3_3_0 rsVersion = new RSMP_Messages.rsVersion_From_3_3_0();
+      RSMP_Messages.rsVersion_All rsVersion = new RSMP_Messages.rsVersion_All();
 
       int iIndex;
 
@@ -782,6 +782,10 @@ namespace nsRSMPGS
           rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions[iIndex]));
         }
       }
+
+#if _RSMPGS1
+      rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
+#endif
 
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -837,8 +837,7 @@ namespace nsRSMPGS
 
       try
       {
-        RSMP_Messages.rsVersion_Until_3_3_0 rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_Until_3_3_0>(sJSon);
-
+        RSMP_Messages.rsVersion_All rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_All>(sJSon);
         cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
         foreach (RSMP_Messages.Version_RSMP Version_RSMP in rsVersion.RSMP)
@@ -863,6 +862,12 @@ namespace nsRSMPGS
         bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
 
 #if _RSMPGS1
+        if (HighestRSMPVersion == RSMPVersion.RSMP_3_3_0)
+        {
+          // If 3.3.0. RSMPGS1 doesn't care 
+          bSXLVersionIsOk = true;
+        }
+
         SendAlarms = rsVersion.receiveAlarms;
 
         if(!SendAlarms)

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -177,9 +177,16 @@ namespace nsRSMPGS
             case "version":
 
               // Only validate using the required fields or the version message
+
+              // RSMPGS1: Only validate using rsVersion_Base since "SXL" doesn't
+              // exist in the response from RSMPGS2 when using 3.3.0
+#if _RSMPGS1
+              bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.rsVersion_Base), sJSon, ref sError) &&
+                ValidatePropertiesString(Header.type, "Version", ref sError);
+#else
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.rsVersion_Until_3_3_0), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "Version", ref sError);
-
+#endif
               break;
 
             case "messageack":
@@ -755,7 +762,12 @@ namespace nsRSMPGS
     public cJSonMessageIdAndTimeStamp CreateAndSendVersionMessage_From_3_3_0()
     {
 
-      RSMP_Messages.rsVersion_All rsVersion = new RSMP_Messages.rsVersion_All();
+#if _RSMPGS1
+      RSMP_Messages.rsVersionRequest_From_3_3_0 rsVersion = new RSMP_Messages.rsVersionRequest_From_3_3_0();
+#endif
+#if _RSMPGS2
+      RSMP_Messages.rsVersionResponse_From_3_3_0 rsVersion = new RSMP_Messages.rsVersionResponse_From_3_3_0();
+#endif
 
       int iIndex;
 
@@ -841,7 +853,7 @@ namespace nsRSMPGS
 
       try
       {
-        RSMP_Messages.rsVersion_All rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_All>(sJSon);
+        RSMP_Messages.rsVersionResponse_Generic rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersionResponse_Generic>(sJSon);
         cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
         foreach (RSMP_Messages.Version_RSMP Version_RSMP in rsVersion.RSMP)

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -783,7 +783,6 @@ namespace nsRSMPGS
         }
       }
 
-      rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {
         RSMP_Messages.SiteId sId = new RSMP_Messages.SiteId();

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -316,18 +316,23 @@ namespace RSMP_Messages
     public string SXL;
   }
 
-  public class rsVersion_From_3_3_0 : rsVersion_Base 
+  public class rsVersionRequest_From_3_3_0 : rsVersion_Base 
+  {
+    public bool receiveAlarms = true;
+    public string step;
+    public string SXL;
+  }
+
+  public class rsVersionResponse_From_3_3_0 : rsVersion_Base
   {
     public bool receiveAlarms = true;
     public string step;
   }
 
   // Needed for validation
-  public class rsVersion_All : rsVersion_Base
+  public class rsVersionResponse_Generic : rsVersionResponse_From_3_3_0
   {
     public string SXL;
-    public bool receiveAlarms = true;
-    public string step;
   }
 
   public class Version_RSMP

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -309,12 +309,11 @@ namespace RSMP_Messages
 
     public List<Version_RSMP> RSMP; // Versions
     public List<SiteId> siteId; // SiteId's
-
-    public string SXL;  // Signal Exchange List
   }
 
   public class rsVersion_Until_3_3_0 : rsVersion_Base
   {
+    public string SXL;  // Signal Exchange List
   }
 
   public class rsVersion_From_3_3_0 : rsVersion_Base 

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -313,12 +313,19 @@ namespace RSMP_Messages
 
   public class rsVersion_Until_3_3_0 : rsVersion_Base
   {
-    public string SXL;  // Signal Exchange List
+    public string SXL;
   }
 
   public class rsVersion_From_3_3_0 : rsVersion_Base 
   {
+    public bool receiveAlarms = true;
+    public string step;
+  }
 
+  // Needed for validation
+  public class rsVersion_All : rsVersion_Base
+  {
+    public string SXL;
     public bool receiveAlarms = true;
     public string step;
   }


### PR DESCRIPTION
As discussed in https://github.com/rsmp-nordic/rsmp_core/pull/277, the version response from RSMPGS2 should no longer contain "SXL" when using RSMP 3.3.0. Wait until https://github.com/rsmp-nordic/rsmp_core/pull/277 is merged.