### PR TITLE
Fix crash for empty field type in YAML

### DIFF
--- a/RSMPCommon/RSMPGS_Objects.cs
+++ b/RSMPCommon/RSMPGS_Objects.cs
@@ -546,7 +546,10 @@ namespace nsRSMPGS
 
     public string GetValueType()
     {
-      return ValueTypeObject.GetValueTypeAsString();
+      if (ValueTypeObject != null)
+        return ValueTypeObject.GetValueTypeAsString();
+      else
+        return "(type not found)";
     }
 
     public void SetInitialUnknownValue()

--- a/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main_Status.cs
+++ b/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main_Status.cs
@@ -388,16 +388,19 @@ namespace nsRSMPGS
 
       lvItem = listview.SelectedItems[0];
       cStatusReturnValue StatusReturnValue = (cStatusReturnValue)lvItem.Tag;
-      cStatusObject StatusObject = StatusReturnValue.StatusObject;
-
-      try
+      if (StatusReturnValue.Value.ValueTypeObject != null)
       {
-        string sValue = StatusReturnValue.Value.GetValue().ToString();
-        List<Dictionary<string, object>> array = StatusReturnValue.Value.GetArray();
-        cFormsHelper.InputStatusBoxValueType("View status", ref sValue, ref array, StatusReturnValue.Value, StatusReturnValue.sComment, true, true);
+        cStatusObject StatusObject = StatusReturnValue.StatusObject;
+
+        try
+        {
+          string sValue = StatusReturnValue.Value.GetValue().ToString();
+          List<Dictionary<string, object>> array = StatusReturnValue.Value.GetArray();
+          cFormsHelper.InputStatusBoxValueType("View status", ref sValue, ref array, StatusReturnValue.Value, StatusReturnValue.sComment, true, true);
+        }
+        catch
+        { }
       }
-      catch
-      { }
     }
   }
 }


### PR DESCRIPTION
Avoid to crash when displaying lists if empty field 'type' in YAML + when double-click it to view status.