### PR TITLE
Disable 'send test JSON' buttons if not connected + little refactoring

### DIFF
--- a/RSMPCommon/RSMPGS_Helper.cs
+++ b/RSMPCommon/RSMPGS_Helper.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 using RSMP_Messages;
 using System.Drawing.Printing;
 using nsRSMPGS.Properties;
+using System.Net.NetworkInformation;
 
 namespace nsRSMPGS
 {
@@ -3076,6 +3077,23 @@ namespace nsRSMPGS
           sBase64 = null;
         }
         combobox.Text = sBase64;
+      }
+    }
+
+    public static void browseFileToLoadInTextBox( OpenFileDialog openFileDialog, TextBox textBoxToLoad )
+    {
+      if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+      {
+        try
+        {
+          textBoxToLoad.Clear();
+          StreamReader swTestPackageFile = new StreamReader((System.IO.Stream)File.OpenRead(openFileDialog.FileName));
+          textBoxToLoad.Text = swTestPackageFile.ReadToEnd();
+          swTestPackageFile.Close();
+        }
+        catch
+        {
+        }
       }
     }
   }

--- a/RSMPCommon/RSMPGS_Main.cs
+++ b/RSMPCommon/RSMPGS_Main.cs
@@ -1065,6 +1065,8 @@ namespace nsRSMPGS
               break;
           }
         }
+        button_SendTestPackage_1.Enabled = RSMPGS.RSMPConnection.ConnectionStatus() == cTcpSocket.ConnectionStatus_Connected;
+        button_SendTestPackage_2.Enabled = button_SendTestPackage_1.Enabled;
         this.Refresh();
       }
 

--- a/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main_TestSend.cs
+++ b/RSMPGS1/RSMPGS1_Main/RSMPGS1_Main_TestSend.cs
@@ -25,36 +25,12 @@ namespace nsRSMPGS
 
     private void button_TestPackage_1_Browse_Click(object sender, EventArgs e)
     {
-      if (openFileDialog_TestPackage.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-      {
-        try
-        {
-          textBox_TestPackage_1.Clear();
-          StreamReader swTestPackageFile = new StreamReader((System.IO.Stream)File.OpenRead(openFileDialog_TestPackage.FileName));
-          textBox_TestPackage_1.Text = swTestPackageFile.ReadToEnd();
-          swTestPackageFile.Close();
-        }
-        catch
-        {
-        }
-      }
+      cFormsHelper.browseFileToLoadInTextBox(openFileDialog_TestPackage, textBox_TestPackage_1);
     }
 
     private void button_TestPackage_2_Browse_Click(object sender, EventArgs e)
     {
-      if (openFileDialog_TestPackage.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-      {
-        try
-        {
-          textBox_TestPackage_2.Clear();
-          StreamReader swTestPackageFile = new StreamReader((System.IO.Stream)File.OpenRead(openFileDialog_TestPackage.FileName));
-          textBox_TestPackage_2.Text = swTestPackageFile.ReadToEnd();
-          swTestPackageFile.Close();
-        }
-        catch
-        {
-        }
-      }
+      cFormsHelper.browseFileToLoadInTextBox(openFileDialog_TestPackage, textBox_TestPackage_2);
     }
   }
 

--- a/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main_TestSend.cs
+++ b/RSMPGS2/RSMPGS2_Main/RSMPGS2_Main_TestSend.cs
@@ -26,36 +26,12 @@ namespace nsRSMPGS
 
     private void button_TestPackage_1_Browse_Click(object sender, EventArgs e)
     {
-      if (openFileDialog_TestPackage.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-      {
-        try
-        {
-          textBox_TestPackage_1.Clear();
-          StreamReader swTestPackageFile = new StreamReader((System.IO.Stream)File.OpenRead(openFileDialog_TestPackage.FileName));
-          textBox_TestPackage_1.Text = swTestPackageFile.ReadToEnd();
-          swTestPackageFile.Close();
-        }
-        catch
-        {
-        }
-      }
+      cFormsHelper.browseFileToLoadInTextBox(openFileDialog_TestPackage, textBox_TestPackage_1);
     }
 
     private void button_TestPackage_2_Browse_Click(object sender, EventArgs e)
     {
-      if (openFileDialog_TestPackage.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-      {
-        try
-        {
-          textBox_TestPackage_2.Clear();
-          StreamReader swTestPackageFile = new StreamReader((System.IO.Stream)File.OpenRead(openFileDialog_TestPackage.FileName));
-          textBox_TestPackage_2.Text = swTestPackageFile.ReadToEnd();
-          swTestPackageFile.Close();
-        }
-        catch
-        {
-        }
-      }
+      cFormsHelper.browseFileToLoadInTextBox(openFileDialog_TestPackage, textBox_TestPackage_2);
     }
   }
 


### PR DESCRIPTION
Disable send test JSON buttons if not connected (a bit misleading if you haven't spotted it, especially as the message sent isn't logged)
and also a little refactoring by creating commun function cFormsHelper.browseFileToLoadInTextBox used 4 times !