### PR TITLE
1.0.15

### DIFF
--- a/Documents/Manual_RSMPGS1.rst
+++ b/Documents/Manual_RSMPGS1.rst
@@ -30,7 +30,7 @@ RSMPGS2   Interface simulator for supervision system
 
 Installation
 ------------
-Start installation by running ``RSMPGS1_1_0_14_Setup.exe``.
+Start installation by running ``RSMPGS1_1_0_15_Setup.exe``.
 
 The installation program recommends a suitable folder.
 

--- a/Documents/Manual_RSMPGS2.rst
+++ b/Documents/Manual_RSMPGS2.rst
@@ -30,7 +30,7 @@ RSMPGS2   Interface simulator for supervision system
 
 Installation
 ------------
-Start installation by running ``RSMPGS2_1_0_14_Setup.exe``.
+Start installation by running ``RSMPGS2_1_0_15_Setup.exe``.
 
 The installation program recommends a suitable folder.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ on the [release page](https://github.com/rsmp-nordic/rsmp_simulator/releases).
 
 Installation
 ------------
-Run `RSMPGS1_1_0_14_Setup.exe` (for road side equipment) or
-`RSMPGS2_1_0_14_Setup.exe` (for supervision system) from
+Run `RSMPGS1_1_0_15_Setup.exe` (for road side equipment) or
+`RSMPGS2_1_0_15_Setup.exe` (for supervision system) from
 the [release page](https://github.com/rsmp-nordic/rsmp_simulator/releases)
 
 Report issues

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -693,7 +693,15 @@ namespace nsRSMPGS
     public cJSonMessageIdAndTimeStamp CreateAndSendVersionMessage()
     {
 #if _RSMPGS1
-      return CreateAndSendVersionMessage_Until_3_3_0();
+      cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
+      if (setting.GetActualValue(RSMPVersion.RSMP_3_3_0))
+      {
+        return CreateAndSendVersionMessage_From_3_3_0();
+      }
+      else
+      {
+        return CreateAndSendVersionMessage_Until_3_3_0();
+      }
 #endif
 
 #if _RSMPGS2
@@ -808,6 +816,12 @@ namespace nsRSMPGS
 #if _RSMPGS1
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
 #endif
+
+      rsVersion.SXLS = new List<Version_SXL>();
+      RSMP_Messages.Version_SXL vSXL = new RSMP_Messages.Version_SXL();
+      vSXL.name = RSMPGS.ProcessImage.sSXLName;
+      vSXL.version = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
+      rsVersion.SXLS.Add(vSXL);
 
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -716,6 +716,7 @@ namespace nsRSMPGS
 
       cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
+# if _RSMPGS1
       for (iIndex = 1; iIndex < sRSMPVersions.GetLength(0); iIndex++)
       {
         if (setting.GetActualValue((RSMPVersion)iIndex))
@@ -723,7 +724,11 @@ namespace nsRSMPGS
           rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions[iIndex]));
         }
       }
-      
+#else
+      // Only send the highest supported version, which will be the negotiated version
+      rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions.Last()));
+#endif
+
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {
@@ -775,6 +780,7 @@ namespace nsRSMPGS
 
       cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
+# if _RSMPGS1
       for (iIndex = 1; iIndex < sRSMPVersions.GetLength(0); iIndex++)
       {
         if (setting.GetActualValue((RSMPVersion)iIndex))
@@ -782,6 +788,10 @@ namespace nsRSMPGS
           rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions[iIndex]));
         }
       }
+#else
+      // Only send the highest supported version, which will be the negotiated version
+      rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions.Last()));
+#endif
 
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)

--- a/RSMPCommon/RSMPGS_JSon.cs
+++ b/RSMPCommon/RSMPGS_JSon.cs
@@ -177,9 +177,16 @@ namespace nsRSMPGS
             case "version":
 
               // Only validate using the required fields or the version message
+
+              // RSMPGS1: Only validate using rsVersion_Base since "SXL" doesn't
+              // exist in the response from RSMPGS2 when using 3.3.0
+#if _RSMPGS1
+              bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.rsVersion_Base), sJSon, ref sError) &&
+                ValidatePropertiesString(Header.type, "Version", ref sError);
+#else
               bSuccess = ValidateJSONProperties(typeof(RSMP_Messages.rsVersion_Until_3_3_0), sJSon, ref sError) &&
                 ValidatePropertiesString(Header.type, "Version", ref sError);
-
+#endif
               break;
 
             case "messageack":
@@ -760,7 +767,12 @@ namespace nsRSMPGS
     public cJSonMessageIdAndTimeStamp CreateAndSendVersionMessage_From_3_3_0()
     {
 
-      RSMP_Messages.rsVersion_From_3_3_0 rsVersion = new RSMP_Messages.rsVersion_From_3_3_0();
+#if _RSMPGS1
+      RSMP_Messages.rsVersionRequest_From_3_3_0 rsVersion = new RSMP_Messages.rsVersionRequest_From_3_3_0();
+#endif
+#if _RSMPGS2
+      RSMP_Messages.rsVersionResponse_From_3_3_0 rsVersion = new RSMP_Messages.rsVersionResponse_From_3_3_0();
+#endif
 
       int iIndex;
 
@@ -793,7 +805,10 @@ namespace nsRSMPGS
       rsVersion.RSMP.Add(new RSMP_Messages.Version_RSMP(sRSMPVersions.Last()));
 #endif
 
+#if _RSMPGS1
       rsVersion.SXL = RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text;
+#endif
+
       foreach (cSiteIdObject SiteIdObject in RSMPGS.ProcessImage.SiteIdObjects)
       {
         RSMP_Messages.SiteId sId = new RSMP_Messages.SiteId();
@@ -848,8 +863,7 @@ namespace nsRSMPGS
 
       try
       {
-        RSMP_Messages.rsVersion_From_3_3_0 rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersion_From_3_3_0>(sJSon);
-
+        RSMP_Messages.rsVersionResponse_Generic rsVersion = JSonSerializer.Deserialize<RSMP_Messages.rsVersionResponse_Generic>(sJSon);
         cSetting setting = RSMPGS.Settings["AllowUseRSMPVersion"];
 
         foreach (RSMP_Messages.Version_RSMP Version_RSMP in rsVersion.RSMP)
@@ -871,9 +885,16 @@ namespace nsRSMPGS
             RSMPGS.SysLog.SysLog(cSysLogAndDebug.Severity.Warning, "Client RSMP version '{0}' is unknown", Version_RSMP.vers.Trim());
           }
         }
-        bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
+        if(rsVersion.SXL != null)
+          bSXLVersionIsOk = (rsVersion.SXL.Trim() == RSMPGS.MainForm.textBox_SignalExchangeListVersion.Text.Trim());
 
 #if _RSMPGS1
+        if (HighestRSMPVersion == RSMPVersion.RSMP_3_3_0)
+        {
+          // If 3.3.0. RSMPGS1 doesn't care 
+          bSXLVersionIsOk = true;
+        }
+
         SendAlarms = rsVersion.receiveAlarms;
 
         if(!SendAlarms)

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -320,19 +320,27 @@ namespace RSMP_Messages
   {
     public bool receiveAlarms = true;
     public string step;
-    public string SXL;
+    public string SXL; // Empty, kept for backwards compatibility
+    public List<Version_SXL> SXLS;
   }
 
   public class rsVersionResponse_From_3_3_0 : rsVersion_Base
   {
     public bool receiveAlarms = true;
     public string step;
+    public List<Version_SXL> SXLS;
   }
 
   // Needed for validation
   public class rsVersionResponse_Generic : rsVersionResponse_From_3_3_0
   {
     public string SXL;
+  }
+
+  public class Version_SXL
+  {
+    public string version;
+    public string name;
   }
 
   public class Version_RSMP

--- a/RSMPCommon/RSMPGS_Messages.cs
+++ b/RSMPCommon/RSMPGS_Messages.cs
@@ -309,19 +309,30 @@ namespace RSMP_Messages
 
     public List<Version_RSMP> RSMP; // Versions
     public List<SiteId> siteId; // SiteId's
-
-    public string SXL;  // Signal Exchange List
   }
 
   public class rsVersion_Until_3_3_0 : rsVersion_Base
   {
+    public string SXL;
   }
 
-  public class rsVersion_From_3_3_0 : rsVersion_Base 
+  public class rsVersionRequest_From_3_3_0 : rsVersion_Base 
   {
-
     public bool receiveAlarms = true;
     public string step;
+    public string SXL;
+  }
+
+  public class rsVersionResponse_From_3_3_0 : rsVersion_Base
+  {
+    public bool receiveAlarms = true;
+    public string step;
+  }
+
+  // Needed for validation
+  public class rsVersionResponse_Generic : rsVersionResponse_From_3_3_0
+  {
+    public string SXL;
   }
 
   public class Version_RSMP

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -336,11 +336,6 @@ namespace nsRSMPGS
 
             RoadSideObject.bIsComponentGroup = YAMLSiteObjectType.YAMLMappings.ContainsKey("aggregated_status");
 
-            if (RoadSideObject.sComponentId.Length == 0 && RoadSideObject.sNTSObjectId.Length == 0)
-            {
-              continue;
-            }
-
             string sKey = RoadSideObject.sNTSObjectId + "\t" + RoadSideObject.sComponentId;
 
             if (RoadSideObjects.ContainsKey(sKey))

--- a/RSMPCommon/RSMPGS_ProcessImage.cs
+++ b/RSMPCommon/RSMPGS_ProcessImage.cs
@@ -49,6 +49,7 @@ namespace nsRSMPGS
     public int MaxAlarmReturnValues = 0;
 
     public string sSXLRevision = "";
+    public string sSXLName = "";
     public int ObjectFilesTimeStamp = 0;
 
 #if _RSMPGS1
@@ -79,6 +80,7 @@ namespace nsRSMPGS
       AggregatedStatusObjects.Clear();
       MaxAlarmReturnValues = 0;
       sSXLRevision = "";
+      sSXLName = "";
       ObjectFilesTimeStamp = 0;
       ValueTypeObjects.Clear();
 
@@ -131,6 +133,7 @@ namespace nsRSMPGS
       // ProcessImage.sId = YAML.GetScalar("id");
 
       sSXLRevision = YAML.GetScalar("version");
+      sSXLName = YAML.GetScalar("name");
 
       //ProcessImage.sDescription = YAML.GetScalar("description");
       //ProcessImage.sConstructor = YAML.GetScalar("constructor");
@@ -1018,6 +1021,7 @@ namespace nsRSMPGS
               // ;;;;1.3;;;
               // Just take the last line...
               sSXLRevision = cHelper.Item(sLine, 1, ';').Trim();
+              // sSXLName doesn't exist in CSV files
               break;
           }
 

--- a/RSMPGS1/Properties/AssemblyInfo.cs
+++ b/RSMPGS1/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.14")]
-[assembly: AssemblyFileVersion("1.0.14")]
+[assembly: AssemblyVersion("1.0.15")]
+[assembly: AssemblyFileVersion("1.0.15")]

--- a/RSMPGS1/RSMPGS1.cs
+++ b/RSMPGS1/RSMPGS1.cs
@@ -104,7 +104,10 @@ using System.Security.Authentication;
 //                           / RSMP 3.3.0: Support "Step" in version message
 //                           / RSMPGS2: Provide supported RSMP version in "rea" in MessageNotAck
 //                           / Rename "Object" to "Components"
-//
+// 26.05.27 / DO / 1.0.15    / RSMP 3.3.0: Add initial support for SXLS in the version message
+//                           / RSMP 3.3.0: Do Not send SXL in version response
+//                           / RSMPGS2: Only send the negotiated RSMP version in the version response
+//                           / Add ability to use empty "cId" for main component
 //
 //
 // ---------------------------------------------------------------------------------------------------

--- a/RSMPGS2/Properties/AssemblyInfo.cs
+++ b/RSMPGS2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.14")]
-[assembly: AssemblyFileVersion("1.0.14")]
+[assembly: AssemblyVersion("1.0.15")]
+[assembly: AssemblyFileVersion("1.0.15")]

--- a/RSMPGS2/RSMPGS2.cs
+++ b/RSMPGS2/RSMPGS2.cs
@@ -97,7 +97,10 @@ using System.Security.Authentication;
 //                           / RSMP 3.3.0: Support "Step" in version message
 //                           / RSMPGS2: Provide supported RSMP version in "rea" in MessageNotAck
 //                           / Rename "Object" to "Components"
-//
+// 26.05.27 / DO / 1.0.15    / RSMP 3.3.0: Add initial support for SXLS in the version message
+//                           / RSMP 3.3.0: Do Not send SXL in version response
+//                           / RSMPGS2: Only send the negotiated RSMP version in the version response
+//                           / Add ability to use empty "cId" for main component
 //
 //
 // ---------------------------------------------------------------------------------------------------

--- a/install_script.iss
+++ b/install_script.iss
@@ -5,8 +5,8 @@
 #define Name "RSMPGS2"
 #define Description "SCADA Interface simulator"
 #endif
-#define Version "1.0.14"
-#define Version_ "1_0_14"
+#define Version "1.0.15"
+#define Version_ "1_0_15"
 
 [Setup]
 AppName={#Name} ({#Description})


### PR DESCRIPTION
- RSMP 3.3.0: Add ability to use empty "cId" for main component
- RSMPGS2: Only send the negotiated RSMP version in the version response. Behavior updated to match RSMP 3.3.0 but this change affects all RSMP versions
- RSMP 3.3.0: Do not send "SXL" in version response
- RSMP 3.3.0: Add initial support for SXLS in the version message